### PR TITLE
Disable coloring when kubectl plugin

### DIFF
--- a/command/runner.go
+++ b/command/runner.go
@@ -60,7 +60,6 @@ func Run(args []string, version string) error {
 	cmd.Stdin = os.Stdin
 
 	// when should not colorize, just run command and return
-	// TODO: right now, krew is unsupported by kubecolor but it should be.
 	if !shouldColorize {
 		cmd.Stdout = Stdout
 		cmd.Stderr = Stderr

--- a/command/subcommand.go
+++ b/command/subcommand.go
@@ -66,6 +66,7 @@ func isColoringSupported(sc kubectl.Subcommand) bool {
 		kubectl.Run,
 		kubectl.Ctx,
 		kubectl.Ns,
+		kubectl.KubectlPlugin,
 	}
 
 	for _, u := range unsupported {


### PR DESCRIPTION
# Description

Disables coloring whenever running a kubectl plugin, e.g kubectl-krew or kubectl-virt

Does this by checking if `kubectl-{arg}` exists in `PATH`

Have some plugins that want to grab the full terminal to do interactive stuff, which is only possible when you feed it the STDIN & STDERR directly, i.e whenever coloring by kubecolor is disabled

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you changed

- Added new subcommand type: `KubectlPlugin`
- Added `KubectlPlugin` to list of commands that doesn't support coloring

## Why you think we should change it

Bugfix

## Related issue (if exists)

N/A
