### PR TITLE
Don't color the "debug" subcommand

### DIFF
--- a/command/subcommand.go
+++ b/command/subcommand.go
@@ -66,6 +66,7 @@ func isColoringSupported(sc kubectl.Subcommand) bool {
 		kubectl.Run,
 		kubectl.Ctx,
 		kubectl.Ns,
+		kubectl.Debug,
 	}
 
 	for _, u := range unsupported {

--- a/kubectl/subcommand.go
+++ b/kubectl/subcommand.go
@@ -72,6 +72,7 @@ const (
 	Options
 	Ctx
 	Ns
+	Debug
 )
 
 var strToSubcommand = map[string]Subcommand{
@@ -119,6 +120,7 @@ var strToSubcommand = map[string]Subcommand{
 	"options":       Options,
 	"ctx":           Ctx,
 	"ns":            Ns,
+	"debug":         Debug,
 }
 
 func InspectSubcommand(command string) (Subcommand, bool) {


### PR DESCRIPTION
It works similarly to the "exec" or "run" subcommands in that it spawns a shell in a pod, so shouldn't be handled by kubecolor as it otherwise mangles the output.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update