### PR TITLE
Set Docker labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,7 @@ RUN go build -o /go/bin/kubecolor cmd/kubecolor/main.go
 FROM gcr.io/distroless/base
 COPY --from=build /go/bin/kubecolor /
 ENTRYPOINT ["/kubecolor"]
+
+LABEL org.opencontainers.image.source=https://github.com/kubecolor/kubecolor
+LABEL org.opencontainers.image.description="Colorize your kubectl output"
+LABEL org.opencontainers.image.licenses=MIT


### PR DESCRIPTION
# Description

Sets the opencontainers labels.

These are required for GH container registry to correlate images with repositories.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you changed

Added `LABEL` statements to Dockerfile

## Why you think we should change it

## Related issue (if exists)
