### PR TITLE
Docker version and non-root

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Git
+.git
+.gitignore
+.gitattributes
+
+# Docker (don't actually need these in Docker builds)
+.dockerignore
+Dockerfile
+
+# Documentation
+**/*.md
+**/*.txt
+LICENSE
+
+# Build files
+Makefile
+.github
+
+# Data
+**/*.yml
+**/*.yaml

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -30,6 +30,8 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:${{ github.sha }}
+          build-args:
+            VERSION=${{ github.sha }}
   push_to_registry_on_tag:
     name: Push docker image to GitHub Container Registry on tag
     runs-on: ubuntu-latest
@@ -55,3 +57,5 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}:${{ github.ref_name}}
             ghcr.io/${{ github.repository }}:latest
+          build-args:
+            VERSION=${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
 FROM golang:1.21 as build
 
 WORKDIR /go/src/kubecolor
-ADD . /go/src/kubecolor/
+COPY go.mod go.sum .
+RUN go mod download
 
-RUN go build -o /go/bin/kubecolor cmd/kubecolor/main.go
+COPY . .
+ARG VERSION=unset
+RUN go install -ldflags="-X main.Version=${VERSION}" ./cmd/kubecolor
 
-FROM gcr.io/distroless/base
-COPY --from=build /go/bin/kubecolor /
-ENTRYPOINT ["/kubecolor"]
+FROM gcr.io/distroless/base:nonroot
+COPY --from=build /go/bin/kubecolor /usr/local/bin/
+COPY --from=bitnami/kubectl /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
+ENTRYPOINT ["kubecolor"]
 
 LABEL org.opencontainers.image.source=https://github.com/kubecolor/kubecolor
 LABEL org.opencontainers.image.description="Colorize your kubectl output"


### PR DESCRIPTION
# Description

Changes to the Dockerfile.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you changed

- Added .dockerignore to make better use of the caching
- Added extra step with `go mod download` to cache the dependencies separately
- Added build arg to supply the version
- Added kubectl to image (by copying from the bitnami/kubectl image)
- Changed to distroless nonroot image

## Why you think we should change it

Various improvements to the Docker image.

Kubectl is a nice to have here, as kubecolor quite heavily relies on it.

## Related issue (if exists)
