### PR TITLE
Fixed describe table detection

### DIFF
--- a/internal/bytesutil/bytesutil.go
+++ b/internal/bytesutil/bytesutil.go
@@ -1,0 +1,48 @@
+package bytesutil
+
+import (
+	"bytes"
+	"strings"
+)
+
+func IndexOfNonSpace(b []byte, spaceCharset string) int {
+	for i := 0; i < len(b); i++ {
+		if !strings.ContainsRune(spaceCharset, rune(b[i])) {
+			return i
+		}
+	}
+	return -1
+}
+
+var doubleSpace = []byte("  ")
+
+func IndexOfDoubleSpace(b []byte) int {
+	spaceIndex := bytes.Index(b, doubleSpace)
+	tabIndex := bytes.IndexByte(b, '\t')
+	if spaceIndex >= 0 && tabIndex >= 0 {
+		return min(spaceIndex, tabIndex)
+	}
+	if spaceIndex >= 0 {
+		return spaceIndex
+	}
+	return tabIndex
+}
+
+func CountColumns(b []byte, spaceCharset string) int {
+	var count int
+	for {
+		index := IndexOfNonSpace(b, spaceCharset)
+		if index == -1 {
+			break
+		}
+		b = b[index:]
+		count++
+
+		index = IndexOfDoubleSpace(b)
+		if index == -1 {
+			break
+		}
+		b = b[index:]
+	}
+	return count
+}

--- a/internal/bytesutil/bytesutil_test.go
+++ b/internal/bytesutil/bytesutil_test.go
@@ -1,0 +1,53 @@
+package bytesutil
+
+import "testing"
+
+func TestCountColumns(t *testing.T) {
+	tests := []struct {
+		name string
+		input string
+		want int
+	}{
+		{
+			name: "empty",
+			input: "",
+			want: 0,
+		},
+
+		{
+			name: "only space",
+			input: "       ",
+			want: 0,
+		},
+
+		{
+			name: "single",
+			input: "foo",
+			want: 1,
+		},
+
+		{
+			name: "three/narrow spacing",
+			input: "foo  bar  moo",
+			want: 3,
+		},
+
+		{
+			// This is where an implementation using [strings.Count] would fail.
+			name: "three/excessive spacing",
+			input: "foo                bar             moo",
+			want: 3,
+		},
+	}
+
+	const spaceCharset = " \t\v"
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CountColumns([]byte(tc.input), spaceCharset)
+			if got != tc.want {
+				t.Errorf("Want %d, got %d\nInput: %q", tc.want, got, tc.input)
+			}
+		})
+	}
+}

--- a/internal/bytesutil/bytesutil_test.go
+++ b/internal/bytesutil/bytesutil_test.go
@@ -40,7 +40,7 @@ func TestCountColumns(t *testing.T) {
 		},
 	}
 
-	const spaceCharset = " \t\v"
+	const spaceCharset = " \t"
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/printer/kubectl_describe.go
+++ b/printer/kubectl_describe.go
@@ -1,12 +1,12 @@
 package printer
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"strings"
 
 	"github.com/kubecolor/kubecolor/color"
+	"github.com/kubecolor/kubecolor/internal/bytesutil"
 	"github.com/kubecolor/kubecolor/scanner/describe"
 )
 
@@ -19,12 +19,11 @@ type DescribePrinter struct {
 func (dp *DescribePrinter) Print(r io.Reader, w io.Writer) {
 	scanner := describe.NewScanner(r)
 	const basicIndentWidth = 2 // according to kubectl describe format
-	doubleSpace := []byte("  ")
 	for scanner.Scan() {
 		line := scanner.Line()
 
 		// when there are multiple columns, treat is as table format
-		if bytes.Count(line.Value, doubleSpace) > 3 {
+		if bytesutil.CountColumns(line.Value, " \t\v") >= 3 {
 			dp.TablePrinter.printLineAsTableFormat(w, line.String(), getColorsByBackground(dp.DarkBackground))
 			continue
 		}

--- a/printer/kubectl_describe.go
+++ b/printer/kubectl_describe.go
@@ -23,7 +23,7 @@ func (dp *DescribePrinter) Print(r io.Reader, w io.Writer) {
 		line := scanner.Line()
 
 		// when there are multiple columns, treat is as table format
-		if bytesutil.CountColumns(line.Value, " \t\v") >= 3 {
+		if bytesutil.CountColumns(line.Value, " \t") >= 3 {
 			dp.TablePrinter.printLineAsTableFormat(w, line.String(), getColorsByBackground(dp.DarkBackground))
 			continue
 		}

--- a/scanner/describe/describe.go
+++ b/scanner/describe/describe.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kubecolor/kubecolor/internal/bytesutil"
 )
 
-var spaceCharset = " \t\v"
+var spaceCharset = " \t"
 var doubleSpace = []byte{' ', ' '}
 
 type Line struct {
@@ -142,7 +142,7 @@ func (s *Scanner) parseLine(b []byte) Line {
 
 	// "  IP:           10.0.0.1"
 	//    ^keyIndex
-	keyIndex := bytesutil.IndexOfNonSpace(b, " \t")
+	keyIndex := bytesutil.IndexOfNonSpace(b, spaceCharset)
 	if keyIndex < 0 {
 		// No chars on this line. Must be empty line.
 		if len(b) > 0 {


### PR DESCRIPTION
# Description

Table detection had faulty logic, resulting in inconsistent coloring.

| Before | After |
| --- | --- |
| ![image](https://github.com/kubecolor/kubecolor/assets/2477952/0bb6bcec-c5d1-4fa0-9bc5-844b55c9a4d5) | ![image](https://github.com/kubecolor/kubecolor/assets/2477952/dd1b2e17-5b6f-4688-ad16-de82a45b4d70)



## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you changed

- Moved some `[]byte` handling to new `internal/bytesutil` package
- Fixed "too many columns" detection to not get confused by lots of spaces in the same cell spacer

## Why you think we should change it

- Fixes issue with coloring

## Related issue (if exists)
