### PR TITLE
Colorize some describe statuses

### DIFF
--- a/printer/kubectl_describe.go
+++ b/printer/kubectl_describe.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 
 	"github.com/kubecolor/kubecolor/color"
@@ -42,9 +43,40 @@ func (dp *DescribePrinter) Print(r io.Reader, w io.Writer) {
 		fmt.Fprintf(w, "%s", line.Spacing)
 		if len(line.Value) > 0 {
 			val := string(line.Value)
-			valColor := getColorByValueType(val, dp.DarkBackground)
+
+			valColor := dp.valueColor(scanner.Path(), val)
 			fmt.Fprint(w, color.Apply(val, valColor))
+
 		}
 		fmt.Fprintf(w, "%s\n", line.Trailing)
 	}
+}
+
+func (dp *DescribePrinter) valueColor(path describe.Path, value string) color.Color {
+	if describeUseStatusColoring(path) {
+		if col, ok := ColorStatus(value); ok {
+			return col
+		}
+	}
+	return getColorByValueType(value, dp.DarkBackground)
+}
+
+var describePathsToColor = []*regexp.Regexp{
+	regexp.MustCompile(`^Status$`),
+	regexp.MustCompile(`^(Init )?Containers/[^/]*/State(/Reason)?$`),
+	regexp.MustCompile(`^Containers/[^/]*/Last State(/Reason)?$`),
+}
+
+func describeUseStatusColoring(path describe.Path) bool {
+	if len(path) == 0 {
+		return false
+	}
+	str := path.String()
+
+	for _, r := range describePathsToColor {
+		if r.MatchString(str) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
# Description

The describe output has some room for improvement.

Colorizing the statuses is certainly a nice start.

This makes use of the describe path that I teased about in #21, and the screenshots show coloring introduced in the (not yet merged) #25

| Before | After |
| --- | ---
| ![image](https://github.com/kubecolor/kubecolor/assets/2477952/9e789974-56d0-4a27-b506-cf3f5143beea) | ![image](https://github.com/kubecolor/kubecolor/assets/2477952/3f2bb9c2-4629-4a5f-8bd2-c2e31f23e9b4)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you changed

- Added status coloring on describe in certain cases, mostly just container status

## Why you think we should change it

More colors :)

## Related issue (if exists)
