### PR TITLE
Added green status coloring

### DIFF
--- a/printer/kubectl_output_colored_printer.go
+++ b/printer/kubectl_output_colored_printer.go
@@ -65,6 +65,9 @@ func ColorStatus(status string) (color.Color, bool) {
 		// Lifecycle hooks
 		"FailedPostStartHook",
 		"FailedPreStopHook",
+		// Node status list
+		"NotReady",
+		"NetworkUnavailable",
 
 		// some other status
 		"ContainerStatusUnknown",
@@ -73,7 +76,10 @@ func ColorStatus(status string) (color.Color, bool) {
 		"Evicted",
 		"FailedScheduling",
 		"Error",
-		"ErrImagePull":
+		"ErrImagePull",
+
+		// PVC status
+		"Lost":
 		return color.Red, true
 	case
 		// from https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/events/event.go
@@ -103,19 +109,36 @@ func ColorStatus(status string) (color.Color, bool) {
 		"ContainerCreating",
 		"PodInitializing",
 		"Terminating",
-		"Warning":
+		"Terminated",
+		"Warning",
+
+		// PV reclaim policy
+		"Delete",
+
+		// PVC status
+		"Available",
+		"Released":
 		return color.Yellow, true
+	case
+		"Running",
+		"Completed",
+		"Pulled",
+		"Created",
+		"Rebooted",
+		"NodeReady",
+		"Started",
+		"Normal",
+		"VolumeResizeSuccessful",
+		"FileSystemResizeSuccessful",
+		"Ready",
+
+		// PV reclaim policy
+		"Retain",
+
+		// PVC status
+		"Bound":
+		return color.Green, true
 	}
-	// some ok status, not colored:
-	// "Pulled",
-	// "Created",
-	// "Rebooted",
-	// "SandboxChanged",
-	// "VolumeResizeSuccessful",
-	// "FileSystemResizeSuccessful",
-	// "NodeReady",
-	// "Started",
-	// "Normal",
 	return 0, false
 }
 


### PR DESCRIPTION
# Description

Having no coloring on OK status is a design choice, but I think its better to enhance it with green coloring.

|  | | 
| --- | ---
| Before | ![image](https://github.com/kubecolor/kubecolor/assets/2477952/7a5694c7-e713-42bf-aea3-fad319da8d66)
| After | ![image](https://github.com/kubecolor/kubecolor/assets/2477952/589ac8dd-60fe-4f76-9eea-a90cc68e17b5)
| |
| Before | ![image](https://github.com/kubecolor/kubecolor/assets/2477952/27b7ca80-ef64-44f5-92d6-7060609461c8)
| After | ![image](https://github.com/kubecolor/kubecolor/assets/2477952/76ba2bbd-433f-4e42-926d-ac1788344a99)




## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you changed

- Added more statuses to be colored
- Added green coloring on OK statuses (nothing was colored green before)

## Why you think we should change it

In certain cases, this makes a it much easier to read

## Related issue (if exists)
