### PR TITLE
Enable Go test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,13 @@ jobs:
         - windows-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
+
     - name: setup go
-      uses: actions/setup-go@v2
-    - name: test
-      run: make coverage
-    - name: upload coverage
-      uses: codecov/codecov-action@v1
+      uses: actions/setup-go@v5
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        go-version-file: go.mod
+
+    - name: test
+      run: go test ./...
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,11 @@ on:
   push:
     branches:
     - "main"
-  pull_request: {}
+  pull_request:
+    paths-ignore:
+      - 'assets/**'
+      - '**.md'
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/scanner/describe/describe_test.go
+++ b/scanner/describe/describe_test.go
@@ -152,6 +152,8 @@ func TestScanner_recreateString(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Read testdata file: %s", err)
 	}
+	// Force CRLF into LF, for Windows
+	b = bytes.ReplaceAll(b, []byte("\r\n"), []byte("\n"))
 
 	var buf bytes.Buffer
 


### PR DESCRIPTION
# Description

Don't know why the tests were disabled, but my suspision is because of the Codecov part?

Maybe it'd be nice with a bunch of linting as well, but at this point let's just get some basic testing going first.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you changed

- Enable Go test workflow
- Removed Codecov integration.
- Ignore paths, such as markdown files. Don't need to run tests just for typo changes
- Fixed test that was failing on Windows due to EOL (CRLF vs LF)

## Why you think we should change it

We do have tests, but we're not running them on every PR.

## Related issue (if exists)
