### PR TITLE
Redesign table parsing

### DIFF
--- a/internal/bytesutil/bytesutil.go
+++ b/internal/bytesutil/bytesutil.go
@@ -1,0 +1,48 @@
+package bytesutil
+
+import (
+	"bytes"
+	"strings"
+)
+
+func IndexOfNonSpace(b []byte, spaceCharset string) int {
+	for i := 0; i < len(b); i++ {
+		if !strings.ContainsRune(spaceCharset, rune(b[i])) {
+			return i
+		}
+	}
+	return -1
+}
+
+var doubleSpace = []byte("  ")
+
+func IndexOfDoubleSpace(b []byte) int {
+	spaceIndex := bytes.Index(b, doubleSpace)
+	tabIndex := bytes.IndexByte(b, '\t')
+	if spaceIndex >= 0 && tabIndex >= 0 {
+		return min(spaceIndex, tabIndex)
+	}
+	if spaceIndex >= 0 {
+		return spaceIndex
+	}
+	return tabIndex
+}
+
+func CountColumns(b []byte, spaceCharset string) int {
+	var count int
+	for {
+		index := IndexOfNonSpace(b, spaceCharset)
+		if index == -1 {
+			break
+		}
+		b = b[index:]
+		count++
+
+		index = IndexOfDoubleSpace(b)
+		if index == -1 {
+			break
+		}
+		b = b[index:]
+	}
+	return count
+}

--- a/printer/kubectl_describe.go
+++ b/printer/kubectl_describe.go
@@ -14,6 +14,8 @@ import (
 type DescribePrinter struct {
 	DarkBackground bool
 	TablePrinter   *TablePrinter
+
+	tableBytes *bytes.Buffer
 }
 
 func (dp *DescribePrinter) Print(r io.Reader, w io.Writer) {
@@ -25,8 +27,14 @@ func (dp *DescribePrinter) Print(r io.Reader, w io.Writer) {
 
 		// when there are multiple columns, treat is as table format
 		if bytes.Count(line.Value, doubleSpace) > 3 {
-			dp.TablePrinter.printLineAsTableFormat(w, line.String(), getColorsByBackground(dp.DarkBackground))
+			if dp.tableBytes == nil {
+				dp.tableBytes = &bytes.Buffer{}
+			}
+			fmt.Fprintln(dp.tableBytes, line.String())
 			continue
+		} else if dp.tableBytes != nil {
+			dp.TablePrinter.Print(dp.tableBytes, w)
+			dp.tableBytes = nil
 		}
 
 		fmt.Fprintf(w, "%s", line.Indent)

--- a/printer/kubectl_describe_test.go
+++ b/printer/kubectl_describe_test.go
@@ -122,17 +122,17 @@ func Test_DescribePrinter_Print(t *testing.T) {
 				  [37mMachine ID[0m:                 [37m55d2ccaefc9847c9a69356e7f3bd23f4[0m
 				  [37mSystem UUID[0m:                [37mfe312784-2364-4bba-a55e-f56051539c21[0m
 				[33mNon-terminated Pods[0m:          [37m(14 in total)[0m
-				[37m[0m  [36mNamespace[0m                   [36mName[0m                                [37mCPU Requests[0m  [36mCPU Limits[0m  [37mMemory Requests[0m  [36mMemory Limits[0m  [37mAGE[0m
-				[37m[0m  [36m---------[0m                   [36m----[0m                                [37m------------[0m  [36m----------[0m  [37m---------------[0m  [36m-------------[0m  [37m---[0m
-				[37m[0m  [36mdefault[0m                     [36mnginx-6799fc88d8-dnmv5[0m              [37m0 (0%)[0m        [36m0 (0%)[0m      [37m0 (0%)[0m           [36m0 (0%)[0m         [37m7d21h[0m
-				[37m[0m  [36mdefault[0m                     [36mnginx-6799fc88d8-m8pbc[0m              [37m0 (0%)[0m        [36m0 (0%)[0m      [37m0 (0%)[0m           [36m0 (0%)[0m         [37m7d21h[0m
-				[37m[0m  [36mdefault[0m                     [36mnginx-6799fc88d8-qdf9b[0m              [37m0 (0%)[0m        [36m0 (0%)[0m      [37m0 (0%)[0m           [36m0 (0%)[0m         [37m7d21h[0m
+				[37m[0m  [36mNamespace[0m                   [37mName[0m                                [36mCPU Requests[0m  [37mCPU Limits[0m  [36mMemory Requests[0m  [37mMemory Limits[0m  [36mAGE[0m
+				[37m[0m  [36m---------[0m                   [37m----[0m                                [36m------------[0m  [37m----------[0m  [36m---------------[0m  [37m-------------[0m  [36m---[0m
+				[37m[0m  [36mdefault[0m                     [37mnginx-6799fc88d8-dnmv5[0m              [36m0 (0%)[0m        [37m0 (0%)[0m      [36m0 (0%)[0m           [37m0 (0%)[0m         [36m7d21h[0m
+				[37m[0m  [36mdefault[0m                     [37mnginx-6799fc88d8-m8pbc[0m              [36m0 (0%)[0m        [37m0 (0%)[0m      [36m0 (0%)[0m           [37m0 (0%)[0m         [36m7d21h[0m
+				[37m[0m  [36mdefault[0m                     [37mnginx-6799fc88d8-qdf9b[0m              [36m0 (0%)[0m        [37m0 (0%)[0m      [36m0 (0%)[0m           [37m0 (0%)[0m         [36m7d21h[0m
 				[33mAllocated resources[0m:
 				  [37m(Total limits may be over 100 percent, i.e., overcommitted.)[0m
-				[37m[0m  [36mResource[0m           [37mRequests[0m    [36mLimits[0m
-				[37m[0m  [36m--------[0m           [37m--------[0m    [36m------[0m
-				[37m[0m  [36mcpu[0m                [37m650m (10%)[0m  [36m0 (0%)[0m
-				[37m[0m  [36mmemory[0m             [37m70Mi (3%)[0m   [36m170Mi (8%)[0m
+				[37m[0m  [37mResource[0m           [37mRequests[0m    [36mLimits[0m
+				[37m[0m  [37m--------[0m           [37m--------[0m    [36m------[0m
+				[37m[0m  [37mcpu[0m                [37m650m (10%)[0m  [36m0 (0%)[0m
+				[37m[0m  [37mmemory[0m             [37m70Mi (3%)[0m   [36m170Mi (8%)[0m
 				[33mEvents[0m:              [33m<none>[0m
 			`),
 		},

--- a/printer/kubectl_describe_test.go
+++ b/printer/kubectl_describe_test.go
@@ -104,7 +104,7 @@ func Test_DescribePrinter_Print(t *testing.T) {
 			expected: testutil.NewHereDoc(`
 				[33mConditions[0m:
 				  [37mType[0m             [36mStatus[0m  [37mLastHeartbeatTime[0m                 [36mLastTransitionTime[0m                [37mReason[0m                       [36mMessage[0m
-				[37m  ----             ------  -----------------                 ------------------                ------                       -------[0m
+				  [37m----[0m             [36m------[0m  [37m-----------------[0m                 [36m------------------[0m                [37m------[0m                       [36m-------[0m
 				  [37mMemoryPressure[0m   [36mFalse[0m   [37mSun, 18 Oct 2020 12:00:54 +0900[0m   [36mWed, 14 Oct 2020 09:28:18 +0900[0m   [37mKubeletHasSufficientMemory[0m   [36mkubelet has sufficient memory available[0m
 				  [37mDiskPressure[0m     [36mFalse[0m   [37mSun, 18 Oct 2020 12:00:54 +0900[0m   [36mWed, 14 Oct 2020 09:28:18 +0900[0m   [37mKubeletHasNoDiskPressure[0m     [36mkubelet has no disk pressure[0m
 				[33mAddresses[0m:
@@ -123,14 +123,14 @@ func Test_DescribePrinter_Print(t *testing.T) {
 				  [37mSystem UUID[0m:                [37mfe312784-2364-4bba-a55e-f56051539c21[0m
 				[33mNon-terminated Pods[0m:          [37m(14 in total)[0m
 				  [37mNamespace[0m                   [36mName[0m                                [37mCPU Requests[0m  [36mCPU Limits[0m  [37mMemory Requests[0m  [36mMemory Limits[0m  [37mAGE[0m
-				[37m  ---------                   ----                                ------------  ----------  ---------------  -------------  ---[0m
+				  [37m---------[0m                   [36m----[0m                                [37m------------[0m  [36m----------[0m  [37m---------------[0m  [36m-------------[0m  [37m---[0m
 				  [37mdefault[0m                     [36mnginx-6799fc88d8-dnmv5[0m              [37m0 (0%)[0m        [36m0 (0%)[0m      [37m0 (0%)[0m           [36m0 (0%)[0m         [37m7d21h[0m
 				  [37mdefault[0m                     [36mnginx-6799fc88d8-m8pbc[0m              [37m0 (0%)[0m        [36m0 (0%)[0m      [37m0 (0%)[0m           [36m0 (0%)[0m         [37m7d21h[0m
 				  [37mdefault[0m                     [36mnginx-6799fc88d8-qdf9b[0m              [37m0 (0%)[0m        [36m0 (0%)[0m      [37m0 (0%)[0m           [36m0 (0%)[0m         [37m7d21h[0m
 				[33mAllocated resources[0m:
 				  [37m(Total limits may be over 100 percent, i.e., overcommitted.)[0m
 				  [37mResource[0m           [36mRequests[0m    [37mLimits[0m
-				[37m  --------           --------    ------[0m
+				  [37m--------[0m           [36m--------[0m    [37m------[0m
 				  [37mcpu[0m                [36m650m (10%)[0m  [37m0 (0%)[0m
 				  [37mmemory[0m             [36m70Mi (3%)[0m   [37m170Mi (8%)[0m
 				[33mEvents[0m:              [33m<none>[0m

--- a/printer/kubectl_describe_test.go
+++ b/printer/kubectl_describe_test.go
@@ -103,10 +103,10 @@ func Test_DescribePrinter_Print(t *testing.T) {
 				Events:              <none>`),
 			expected: testutil.NewHereDoc(`
 				[33mConditions[0m:
-				[37m[0m  [36mType[0m             [37mStatus[0m  [36mLastHeartbeatTime[0m                 [37mLastTransitionTime[0m                [36mReason[0m                       [37mMessage[0m
-				[37m[0m  [36m----[0m             [37m------[0m  [36m-----------------[0m                 [37m------------------[0m                [36m------[0m                       [37m-------[0m
-				[37m[0m  [36mMemoryPressure[0m   [37mFalse[0m   [36mSun, 18 Oct 2020 12:00:54 +0900[0m   [37mWed, 14 Oct 2020 09:28:18 +0900[0m   [36mKubeletHasSufficientMemory[0m   [37mkubelet has sufficient memory available[0m
-				[37m[0m  [36mDiskPressure[0m     [37mFalse[0m   [36mSun, 18 Oct 2020 12:00:54 +0900[0m   [37mWed, 14 Oct 2020 09:28:18 +0900[0m   [36mKubeletHasNoDiskPressure[0m     [37mkubelet has no disk pressure[0m
+				  [37mType[0m             [36mStatus[0m  [37mLastHeartbeatTime[0m                 [36mLastTransitionTime[0m                [37mReason[0m                       [36mMessage[0m
+				[37m  ----             ------  -----------------                 ------------------                ------                       -------[0m
+				  [37mMemoryPressure[0m   [36mFalse[0m   [37mSun, 18 Oct 2020 12:00:54 +0900[0m   [36mWed, 14 Oct 2020 09:28:18 +0900[0m   [37mKubeletHasSufficientMemory[0m   [36mkubelet has sufficient memory available[0m
+				  [37mDiskPressure[0m     [36mFalse[0m   [37mSun, 18 Oct 2020 12:00:54 +0900[0m   [36mWed, 14 Oct 2020 09:28:18 +0900[0m   [37mKubeletHasNoDiskPressure[0m     [36mkubelet has no disk pressure[0m
 				[33mAddresses[0m:
 				  [37mInternalIP[0m:  [37m172.17.0.3[0m
 				  [37mHostname[0m:    [37mminikube[0m
@@ -122,17 +122,17 @@ func Test_DescribePrinter_Print(t *testing.T) {
 				  [37mMachine ID[0m:                 [37m55d2ccaefc9847c9a69356e7f3bd23f4[0m
 				  [37mSystem UUID[0m:                [37mfe312784-2364-4bba-a55e-f56051539c21[0m
 				[33mNon-terminated Pods[0m:          [37m(14 in total)[0m
-				[37m[0m  [36mNamespace[0m                   [37mName[0m                                [36mCPU Requests[0m  [37mCPU Limits[0m  [36mMemory Requests[0m  [37mMemory Limits[0m  [36mAGE[0m
-				[37m[0m  [36m---------[0m                   [37m----[0m                                [36m------------[0m  [37m----------[0m  [36m---------------[0m  [37m-------------[0m  [36m---[0m
-				[37m[0m  [36mdefault[0m                     [37mnginx-6799fc88d8-dnmv5[0m              [36m0 (0%)[0m        [37m0 (0%)[0m      [36m0 (0%)[0m           [37m0 (0%)[0m         [36m7d21h[0m
-				[37m[0m  [36mdefault[0m                     [37mnginx-6799fc88d8-m8pbc[0m              [36m0 (0%)[0m        [37m0 (0%)[0m      [36m0 (0%)[0m           [37m0 (0%)[0m         [36m7d21h[0m
-				[37m[0m  [36mdefault[0m                     [37mnginx-6799fc88d8-qdf9b[0m              [36m0 (0%)[0m        [37m0 (0%)[0m      [36m0 (0%)[0m           [37m0 (0%)[0m         [36m7d21h[0m
+				  [37mNamespace[0m                   [36mName[0m                                [37mCPU Requests[0m  [36mCPU Limits[0m  [37mMemory Requests[0m  [36mMemory Limits[0m  [37mAGE[0m
+				[37m  ---------                   ----                                ------------  ----------  ---------------  -------------  ---[0m
+				  [37mdefault[0m                     [36mnginx-6799fc88d8-dnmv5[0m              [37m0 (0%)[0m        [36m0 (0%)[0m      [37m0 (0%)[0m           [36m0 (0%)[0m         [37m7d21h[0m
+				  [37mdefault[0m                     [36mnginx-6799fc88d8-m8pbc[0m              [37m0 (0%)[0m        [36m0 (0%)[0m      [37m0 (0%)[0m           [36m0 (0%)[0m         [37m7d21h[0m
+				  [37mdefault[0m                     [36mnginx-6799fc88d8-qdf9b[0m              [37m0 (0%)[0m        [36m0 (0%)[0m      [37m0 (0%)[0m           [36m0 (0%)[0m         [37m7d21h[0m
 				[33mAllocated resources[0m:
 				  [37m(Total limits may be over 100 percent, i.e., overcommitted.)[0m
-				[37m[0m  [37mResource[0m           [37mRequests[0m    [36mLimits[0m
-				[37m[0m  [37m--------[0m           [37m--------[0m    [36m------[0m
-				[37m[0m  [37mcpu[0m                [37m650m (10%)[0m  [36m0 (0%)[0m
-				[37m[0m  [37mmemory[0m             [37m70Mi (3%)[0m   [36m170Mi (8%)[0m
+				  [37mResource[0m           [36mRequests[0m    [37mLimits[0m
+				[37m  --------           --------    ------[0m
+				  [37mcpu[0m                [36m650m (10%)[0m  [37m0 (0%)[0m
+				  [37mmemory[0m             [36m70Mi (3%)[0m   [37m170Mi (8%)[0m
 				[33mEvents[0m:              [33m<none>[0m
 			`),
 		},

--- a/printer/kubectl_output_colored_printer_test.go
+++ b/printer/kubectl_output_colored_printer_test.go
@@ -152,9 +152,9 @@ func Test_KubectlOutputColoredPrinter_Print(t *testing.T) {
 				nginx-qdf9b   1/1     Running   0          6d6h`),
 			expected: testutil.NewHereDoc(`
 				[37mNAME          READY   STATUS    RESTARTS   AGE[0m
-				[37mnginx-dnmv5[0m   [36m1/1[0m     [37mRunning[0m   [36m0[0m          [37m6d6h[0m
-				[37mnginx-m8pbc[0m   [36m1/1[0m     [37mRunning[0m   [36m0[0m          [37m6d6h[0m
-				[37mnginx-qdf9b[0m   [36m1/1[0m     [37mRunning[0m   [36m0[0m          [37m6d6h[0m
+				[37mnginx-dnmv5[0m   [36m1/1[0m     [32mRunning[0m   [36m0[0m          [37m6d6h[0m
+				[37mnginx-m8pbc[0m   [36m1/1[0m     [32mRunning[0m   [36m0[0m          [37m6d6h[0m
+				[37mnginx-qdf9b[0m   [36m1/1[0m     [32mRunning[0m   [36m0[0m          [37m6d6h[0m
 			`),
 		},
 		{
@@ -171,8 +171,8 @@ func Test_KubectlOutputColoredPrinter_Print(t *testing.T) {
 			expected: testutil.NewHereDoc(`
 				[37mNAME          READY   STATUS             RESTARTS   AGE[0m
 				[37mnginx-dnmv4[0m   [36m1/1[0m     [31mCrashLoopBackOff[0m   [36m0[0m          [37m6d6h[0m
-				[37mnginx-m8pbc[0m   [36m1/1[0m     [37mRunning[0m            [36m0[0m          [37m6d6h[0m
-				[37mnginx-qdf9b[0m   [33m0/1[0m     [37mRunning[0m            [36m0[0m          [37m6d6h[0m
+				[37mnginx-m8pbc[0m   [36m1/1[0m     [32mRunning[0m            [36m0[0m          [37m6d6h[0m
+				[37mnginx-qdf9b[0m   [33m0/1[0m     [32mRunning[0m            [36m0[0m          [37m6d6h[0m
 			`),
 		},
 		{
@@ -189,9 +189,9 @@ func Test_KubectlOutputColoredPrinter_Print(t *testing.T) {
 				nginx-qdf9b   1/1     Running   0          4m59s`),
 			expected: testutil.NewHereDoc(`
 				[37mNAME          READY   STATUS    RESTARTS   AGE[0m
-				[37mnginx-dnmv6[0m   [36m1/1[0m     [37mRunning[0m   [36m0[0m          [37m6d6h[0m
-				[37mnginx-m8pbc[0m   [36m1/1[0m     [37mRunning[0m   [36m0[0m          [37m5m[0m
-				[37mnginx-qdf9b[0m   [36m1/1[0m     [37mRunning[0m   [36m0[0m          [32m4m59s[0m
+				[37mnginx-dnmv6[0m   [36m1/1[0m     [32mRunning[0m   [36m0[0m          [37m6d6h[0m
+				[37mnginx-m8pbc[0m   [36m1/1[0m     [32mRunning[0m   [36m0[0m          [37m5m[0m
+				[37mnginx-qdf9b[0m   [36m1/1[0m     [32mRunning[0m   [36m0[0m          [32m4m59s[0m
 			`),
 		},
 		{
@@ -206,9 +206,9 @@ func Test_KubectlOutputColoredPrinter_Print(t *testing.T) {
 				nginx-m8pbc   1/1     Running   0          6d6h
 				nginx-qdf9b   1/1     Running   0          6d6h`),
 			expected: testutil.NewHereDoc(`
-				[37mnginx-dnmv5[0m   [36m1/1[0m     [37mRunning[0m   [36m0[0m          [37m6d6h[0m
-				[37mnginx-m8pbc[0m   [36m1/1[0m     [37mRunning[0m   [36m0[0m          [37m6d6h[0m
-				[37mnginx-qdf9b[0m   [36m1/1[0m     [37mRunning[0m   [36m0[0m          [37m6d6h[0m
+				[37mnginx-dnmv5[0m   [36m1/1[0m     [32mRunning[0m   [36m0[0m          [37m6d6h[0m
+				[37mnginx-m8pbc[0m   [36m1/1[0m     [32mRunning[0m   [36m0[0m          [37m6d6h[0m
+				[37mnginx-qdf9b[0m   [36m1/1[0m     [32mRunning[0m   [36m0[0m          [37m6d6h[0m
 			`),
 		},
 		{
@@ -225,9 +225,9 @@ func Test_KubectlOutputColoredPrinter_Print(t *testing.T) {
 				nginx-6799fc88d8-qdf9b   1/1     Running   0          7d10h   172.18.0.3   minikube   <none>           <none>`),
 			expected: testutil.NewHereDoc(`
 				[37mNAME                     READY   STATUS    RESTARTS   AGE     IP           NODE       NOMINATED NODE   READINESS GATES[0m
-				[37mnginx-6799fc88d8-dnmv7[0m   [36m1/1[0m     [37mRunning[0m   [36m0[0m          [37m7d10h[0m   [36m172.18.0.5[0m   [37mminikube[0m   [36m<none>[0m           [37m<none>[0m
-				[37mnginx-6799fc88d8-m8pbc[0m   [36m1/1[0m     [37mRunning[0m   [36m0[0m          [37m7d10h[0m   [36m172.18.0.4[0m   [37mminikube[0m   [36m<none>[0m           [37m<none>[0m
-				[37mnginx-6799fc88d8-qdf9b[0m   [36m1/1[0m     [37mRunning[0m   [36m0[0m          [37m7d10h[0m   [36m172.18.0.3[0m   [37mminikube[0m   [36m<none>[0m           [37m<none>[0m
+				[37mnginx-6799fc88d8-dnmv7[0m   [36m1/1[0m     [32mRunning[0m   [36m0[0m          [37m7d10h[0m   [36m172.18.0.5[0m   [37mminikube[0m   [36m<none>[0m           [37m<none>[0m
+				[37mnginx-6799fc88d8-m8pbc[0m   [36m1/1[0m     [32mRunning[0m   [36m0[0m          [37m7d10h[0m   [36m172.18.0.4[0m   [37mminikube[0m   [36m<none>[0m           [37m<none>[0m
+				[37mnginx-6799fc88d8-qdf9b[0m   [36m1/1[0m     [32mRunning[0m   [36m0[0m          [37m7d10h[0m   [36m172.18.0.3[0m   [37mminikube[0m   [36m<none>[0m           [37m<none>[0m
 			`),
 		},
 		{

--- a/printer/table.go
+++ b/printer/table.go
@@ -66,7 +66,7 @@ func isAllCellsUpper(cells []tablescan.Cell) bool {
 
 func isAllUpper(s string) bool {
 	for _, r := range s {
-		if unicode.IsLower(r) {
+		if !unicode.IsUpper(r) {
 			return false
 		}
 	}

--- a/printer/table.go
+++ b/printer/table.go
@@ -1,22 +1,26 @@
 package printer
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"strings"
+	"unicode"
 
 	"github.com/kubecolor/kubecolor/color"
+	"github.com/kubecolor/kubecolor/scanner/tablescan"
 )
+
+type tableColumnColor struct {
+	IndexInLine int
+	Color       color.Color
+}
 
 type TablePrinter struct {
 	WithHeader     bool
 	DarkBackground bool
 	ColorDeciderFn func(index int, column string) (color.Color, bool)
 
-	isFirstLine   bool
-	indexColorMap map[int]color.Color
-	tempColors    []color.Color
+	hasLeadingNamespaceColumn bool
 }
 
 func NewTablePrinter(withHeader, darkBackground bool, colorDeciderFn func(index int, column string) (color.Color, bool)) *TablePrinter {
@@ -24,110 +28,83 @@ func NewTablePrinter(withHeader, darkBackground bool, colorDeciderFn func(index 
 		WithHeader:     withHeader,
 		DarkBackground: darkBackground,
 		ColorDeciderFn: colorDeciderFn,
-		indexColorMap:  map[int]color.Color{},
-		tempColors:     []color.Color{},
 	}
 }
 
 func (tp *TablePrinter) Print(r io.Reader, w io.Writer) {
-	tp.isFirstLine = true
-	scanner := bufio.NewScanner(r)
+	isFirstLine := true
+	scanner := tablescan.NewScanner(r)
 	for scanner.Scan() {
-		line := scanner.Text()
-		if tp.isHeader(line) {
-			fmt.Fprintf(w, "%s\n", color.Apply(line, getHeaderColorByBackground(tp.DarkBackground)))
-			tp.isFirstLine = false
+		cells := scanner.Cells()
+		if len(cells) == 0 {
+			fmt.Fprint(w, "\n")
+			continue
+		}
+		if (tp.WithHeader && isFirstLine) || isAllCellsUpper(cells) {
+			isFirstLine = false
+			fmt.Fprintf(w, "%s\n", color.Apply(scanner.Text(), getHeaderColorByBackground(tp.DarkBackground)))
+
+			if strings.EqualFold(cells[0].Trimmed, "namespace") {
+				tp.hasLeadingNamespaceColumn = true
+			}
 			continue
 		}
 
-		tp.printLineAsTableFormat(w, line, getColorsByBackground(tp.DarkBackground))
+		fmt.Fprintf(w, "%s", scanner.LeadingSpaces())
+		tp.printLineAsTableFormat(w, cells, getColorsByBackground(tp.DarkBackground))
 	}
 }
 
-func (tp *TablePrinter) isHeader(line string) bool {
-	// If every character is upper case, probably it's a header line.
-	// e.g.
-	// kubecolor get pod,rs
-	// NAME                         READY   STATUS    RESTARTS   AGE
-	// pod/nginx-8spn9              1/1     Running   1          19d
-	// pod/nginx-dplns              1/1     Running   1          19d
-	// pod/nginx-lpv5x              1/1     Running   1          19d
+func isAllCellsUpper(cells []tablescan.Cell) bool {
+	for _, c := range cells {
+		if !isAllUpper(c.Trimmed) {
+			return false
+		}
+	}
+	return true
+}
 
-	// NAME                               DESIRED   CURRENT   READY   AGE <- this
-	// replicaset.apps/nginx              3         3         3       19d
-	// replicaset.apps/nginx-6799fc88d8   3         3         3       19d
-	isEveryCharacterUpper := strings.ToUpper(line) == line
-	return (tp.WithHeader && tp.isFirstLine) || isEveryCharacterUpper
+func isAllUpper(s string) bool {
+	for _, r := range s {
+		if unicode.IsLower(r) {
+			return false
+		}
+	}
+	return true
 }
 
 // printTableFormat prints a line to w in kubectl "table" Format.
 // Table format is something like:
-// ---------------------------------------------------------
-// NAME                     READY   STATUS    RESTARTS   AGE
-// nginx-6799fc88d8-dnmv5   1/1     Running   0          31h
-// nginx-6799fc88d8-m8pbc   1/1     Running   0          31h
-// nginx-6799fc88d8-qdf9b   1/1     Running   0          31h
-// nginx-8spn9              1/1     Running   0          31h
-// nginx-dplns              1/1     Running   0          31h
-// nginx-lpv5x              1/1     Running   0          31h
-// ---------------------------------------------------------
-// This function requires a line and tries to colorize it by each column.
-// If dark is true, use colors which are readable in dark-backgrounded environment, else,
-// it uses colors for light-backgrounded env.
-// This function doesn't respect if the line is "header", so
-// if you want to specify a special color for header, you must not pass the line
-// to this function.
-// deciderFn is a function to return context-specific color to be used to decorate a column.
-// If the function returned ok=true, then returned color will be used for the column.
-// If it returned ok=false, then default configurated color will be used.
-// If deciderFn is null, then this function uses the default configurated color.
-func (tp *TablePrinter) printLineAsTableFormat(w io.Writer, line string, colorsPreset []color.Color) {
-	columns := spaces.Split(line, -1)
-	spacesIndices := spaces.FindAllStringIndex(line, -1)
+//
+//	NAME                     READY   STATUS    RESTARTS   AGE
+//	nginx-6799fc88d8-dnmv5   1/1     Running   0          31h
+//	nginx-6799fc88d8-m8pbc   1/1     Running   0          31h
+//	nginx-6799fc88d8-qdf9b   1/1     Running   0          31h
+//	nginx-8spn9              1/1     Running   0          31h
+//	nginx-dplns              1/1     Running   0          31h
+//	nginx-lpv5x              1/1     Running   0          31h
+func (tp *TablePrinter) printLineAsTableFormat(w io.Writer, cells []tablescan.Cell, colorsPreset []color.Color) {
+	for i, cell := range cells {
+		c := tp.getColumnBaseColor(i, colorsPreset)
 
-	if len(columns) == len(spacesIndices)-1 {
-		// It should not come here.
-		panic("kubecolor: unexpected format as table. this must be a bug of kubecolor")
-	}
-
-	for i, column := range columns {
-		index := 0
-		if i != 0 {
-			index = spacesIndices[i-1][1] + 1
-		}
-
-		c := tp.decideColorForTable(index, colorsPreset)
 		if tp.ColorDeciderFn != nil {
-			if cc, ok := tp.ColorDeciderFn(i, column); ok {
+			if cc, ok := tp.ColorDeciderFn(i, cell.Trimmed); ok {
 				c = cc // prior injected deciderFn result
 			}
 		}
 		// Write colored column
-		fmt.Fprintf(w, "%s", color.Apply(column, c))
-		// Write spaces based on actual output
-		// When writing the most left column, no extra spaces needed.
-		if i <= len(spacesIndices)-1 {
-			spacesIndex := spacesIndices[i]
-			fmt.Fprintf(w, "%s", toSpaces(spacesIndex[1]-spacesIndex[0]))
+		if cell.Trimmed != "" {
+			fmt.Fprint(w, color.Apply(cell.Trimmed, c))
 		}
+		fmt.Fprint(w, cell.TrailingSpaces)
 	}
 
 	fmt.Fprintf(w, "\n")
 }
 
-func (tp *TablePrinter) decideColorForTable(index int, colors []color.Color) color.Color {
-	if len(tp.tempColors) == 0 {
-		tp.tempColors = make([]color.Color, len(colors))
-		copy(tp.tempColors, colors)
+func (tp *TablePrinter) getColumnBaseColor(index int, colorsPreset []color.Color) color.Color {
+	if tp.hasLeadingNamespaceColumn {
+		index++
 	}
-
-	if c, ok := tp.indexColorMap[index]; ok {
-		return c
-	}
-
-	c := tp.tempColors[0]
-	tp.indexColorMap[index] = c
-	tp.tempColors = tp.tempColors[1:]
-
-	return c
+	return colorsPreset[index%len(colorsPreset)]
 }

--- a/printer/table_test.go
+++ b/printer/table_test.go
@@ -56,7 +56,7 @@ func Test_TablePrinter_Print(t *testing.T) {
 				[37mpod/nginx-8spn9[0m              [36m1/1[0m     [37mRunning[0m   [36m1[0m          [37m19d[0m
 				[37mpod/nginx-dplns[0m              [36m1/1[0m     [37mRunning[0m   [36m1[0m          [37m19d[0m
 				[37mpod/nginx-lpv5x[0m              [36m1/1[0m     [37mRunning[0m   [36m1[0m          [37m19d[0m
-				[37m[0m
+
 				[37mNAME                               DESIRED   CURRENT   READY   AGE[0m
 				[37mreplicaset.apps/nginx[0m              [36m3[0m         [37m3[0m         [36m3[0m       [37m19d[0m
 				[37mreplicaset.apps/nginx-6799fc88d8[0m   [36m3[0m         [37m3[0m         [36m3[0m       [37m19d[0m

--- a/scanner/tablescan/tablescan.go
+++ b/scanner/tablescan/tablescan.go
@@ -2,6 +2,7 @@ package tablescan
 
 import (
 	"bufio"
+	"bytes"
 	"io"
 	"strings"
 
@@ -12,6 +13,10 @@ type Cell struct {
 	Trimmed        string
 	Full           string
 	TrailingSpaces string
+}
+
+func (c Cell) String() string {
+	return c.Full
 }
 
 var emptyCell = NewCell("")
@@ -26,10 +31,13 @@ func NewCell(full string) Cell {
 }
 
 type Scanner struct {
-	lineScanner   *bufio.Scanner
-	headerIndices []int
-	currentCells  []Cell
-	leadingSpaces []byte
+	lineScanner     *bufio.Scanner
+	headerIndices   []int
+	currentCells    []Cell
+	currentLine string
+	leadingSpaces   string
+	bufferedLines   []string
+	reuseScanResult bool
 }
 
 func NewScanner(reader io.Reader) *Scanner {
@@ -42,16 +50,16 @@ func (s *Scanner) Cells() []Cell {
 	return s.currentCells
 }
 
-func (s *Scanner) LeadingSpaces() []byte {
+func (s *Scanner) LeadingSpaces() string {
 	return s.leadingSpaces
 }
 
 func (s *Scanner) Bytes() []byte {
-	return s.lineScanner.Bytes()
+	return []byte(s.currentLine)
 }
 
 func (s *Scanner) Text() string {
-	return s.lineScanner.Text()
+	return s.currentLine
 }
 
 func (s *Scanner) Err() error {
@@ -59,29 +67,28 @@ func (s *Scanner) Err() error {
 }
 
 func (s *Scanner) Scan() bool {
-	if !s.lineScanner.Scan() {
+	if !s.bufferTableLines() {
 		return false
 	}
 
-	b := s.lineScanner.Bytes()
+	s.currentLine = s.bufferedLines[0]
+	s.bufferedLines = s.bufferedLines[1:]
 
 	clear(s.currentCells) // let strings get GC'd
 	s.currentCells = s.currentCells[:0]
 
-	if len(b) == 0 {
+	if len(s.currentLine) == 0 {
 		// Empty line. Should reset header calculations then
-		s.headerIndices = nil
+		s.bufferedLines = nil
 		return true
-	} else if s.shouldCalcIndices(b) {
-		s.headerIndices = calcHeaderIndices(b)
 	}
 
 	if len(s.headerIndices) > 0 {
-		s.leadingSpaces = b[:s.headerIndices[0]]
+		s.leadingSpaces = s.currentLine[:s.headerIndices[0]]
 	}
 
 	for i, columnIndex := range s.headerIndices {
-		if columnIndex >= len(b) {
+		if columnIndex >= len(s.currentLine) {
 			// empty cell at end of line
 			s.currentCells = append(s.currentCells, emptyCell)
 			continue
@@ -90,10 +97,10 @@ func (s *Scanner) Scan() bool {
 		if i+1 < len(s.headerIndices) {
 			// there's more lines
 			nextColumnIndex := s.headerIndices[i+1]
-			str = string(b[columnIndex:min(nextColumnIndex, len(b))])
+			str = s.currentLine[columnIndex:min(nextColumnIndex, len(s.currentLine))]
 		} else {
 			// last column
-			str = string(b[columnIndex:])
+			str = s.currentLine[columnIndex:]
 		}
 		s.currentCells = append(s.currentCells, NewCell(str))
 	}
@@ -101,15 +108,54 @@ func (s *Scanner) Scan() bool {
 	return true
 }
 
-func (s *Scanner) shouldCalcIndices(line []byte) bool {
-	if s.headerIndices == nil {
+func (s *Scanner) bufferTableLines() bool {
+	if len(s.bufferedLines) > 0 {
 		return true
 	}
 
+	s.headerIndices = nil
+	var combinedLines []byte
+
+	for {
+		if s.reuseScanResult {
+			s.reuseScanResult = false
+		} else if !s.lineScanner.Scan() {
+			return len(s.bufferedLines) > 0
+		}
+
+		b := s.lineScanner.Bytes()
+
+		if len(b) == 0 {
+			// Empty line. Keep it, but don't process further
+			s.bufferedLines = append(s.bufferedLines, "")
+			return len(s.bufferedLines) > 0
+		}
+
+		combinedLines = bytewiseAndNonSpace(combinedLines, b)
+		newHeaderIndices := calcHeaderIndices(combinedLines)
+
+		if isProbablyNewTable(s.headerIndices, combinedLines) {
+			s.reuseScanResult = true
+			return true
+		}
+
+		s.headerIndices = newHeaderIndices
+
+		// Using [bufio.Scanner.Text], as using result from [bufio.Scanner.Bytes]
+		// after another scan is undefined behavior,
+		// and can lead to corrupted data.
+		s.bufferedLines = append(s.bufferedLines, s.lineScanner.Text())
+	}
+}
+
+func isProbablyNewTable(headerIndices []int, line []byte) bool {
+	if len(headerIndices) == 0 {
+		return false
+	}
 	// Checks if we have come across a new table,
 	// via lossy logic on the heuristic that cells should have spacing.
 	// There will be edge cases where this fails, but it'll be good enough.
-	for _, columnIndex := range s.headerIndices[1:] {
+	for _, columnIndex := range headerIndices[1:] {
 		if columnIndex >= len(line) || columnIndex == 0 {
 			continue
 		}
@@ -122,6 +168,19 @@ func (s *Scanner) shouldCalcIndices(line []byte) bool {
 	}
 
 	return false
+}
+
+func bytewiseAndNonSpace(oldBytes, newBytes []byte) []byte {
+	if len(newBytes) > len(oldBytes) {
+		oldBytes = append(oldBytes, bytes.Repeat([]byte(" "), len(newBytes) - len(oldBytes))...)
+	}
+	for i, b := range newBytes {
+		if b == ' ' {
+			continue
+		}
+		oldBytes[i] = b
+	}
+	return oldBytes
 }
 
 func calcHeaderIndices(line []byte) []int {

--- a/scanner/tablescan/tablescan.go
+++ b/scanner/tablescan/tablescan.go
@@ -1,0 +1,147 @@
+package tablescan
+
+import (
+	"bufio"
+	"io"
+	"strings"
+
+	"github.com/kubecolor/kubecolor/internal/bytesutil"
+)
+
+type Cell struct {
+	Trimmed        string
+	Full           string
+	TrailingSpaces string
+}
+
+var emptyCell = NewCell("")
+
+func NewCell(full string) Cell {
+	trimmed := strings.TrimRight(full, " \t")
+	return Cell{
+		Trimmed:        trimmed,
+		Full:           full,
+		TrailingSpaces: full[len(trimmed):],
+	}
+}
+
+type Scanner struct {
+	lineScanner   *bufio.Scanner
+	headerIndices []int
+	currentCells  []Cell
+	leadingSpaces []byte
+}
+
+func NewScanner(reader io.Reader) *Scanner {
+	return &Scanner{
+		lineScanner: bufio.NewScanner(reader),
+	}
+}
+
+func (s *Scanner) Cells() []Cell {
+	return s.currentCells
+}
+
+func (s *Scanner) LeadingSpaces() []byte {
+	return s.leadingSpaces
+}
+
+func (s *Scanner) Bytes() []byte {
+	return s.lineScanner.Bytes()
+}
+
+func (s *Scanner) Text() string {
+	return s.lineScanner.Text()
+}
+
+func (s *Scanner) Err() error {
+	return s.lineScanner.Err()
+}
+
+func (s *Scanner) Scan() bool {
+	if !s.lineScanner.Scan() {
+		return false
+	}
+
+	b := s.lineScanner.Bytes()
+
+	clear(s.currentCells) // let strings get GC'd
+	s.currentCells = s.currentCells[:0]
+
+	if len(b) == 0 {
+		// Empty line. Should reset header calculations then
+		s.headerIndices = nil
+		return true
+	} else if s.shouldCalcIndices(b) {
+		s.headerIndices = calcHeaderIndices(b)
+	}
+
+	if len(s.headerIndices) > 0 {
+		s.leadingSpaces = b[:s.headerIndices[0]]
+	}
+
+	for i, columnIndex := range s.headerIndices {
+		if columnIndex >= len(b) {
+			// empty cell at end of line
+			s.currentCells = append(s.currentCells, emptyCell)
+			continue
+		}
+		var str string
+		if i+1 < len(s.headerIndices) {
+			// there's more lines
+			nextColumnIndex := s.headerIndices[i+1]
+			str = string(b[columnIndex:min(nextColumnIndex, len(b))])
+		} else {
+			// last column
+			str = string(b[columnIndex:])
+		}
+		s.currentCells = append(s.currentCells, NewCell(str))
+	}
+
+	return true
+}
+
+func (s *Scanner) shouldCalcIndices(line []byte) bool {
+	if s.headerIndices == nil {
+		return true
+	}
+
+	// Checks if we have come across a new table,
+	// via lossy logic on the heuristic that cells should have spacing.
+	// There will be edge cases where this fails, but it'll be good enough.
+	for _, columnIndex := range s.headerIndices[1:] {
+		if columnIndex >= len(line) || columnIndex == 0 {
+			continue
+		}
+		oneBefore := line[max(columnIndex-2, 0)]
+		twoBefore := line[max(columnIndex-2, 0)]
+		if oneBefore != ' ' || twoBefore != ' ' {
+			// should have spacing between columns
+			return true
+		}
+	}
+
+	return false
+}
+
+func calcHeaderIndices(line []byte) []int {
+	var indices []int
+	var indexOffset int
+	for {
+		index := bytesutil.IndexOfNonSpace(line, " \t")
+		if index == -1 {
+			break
+		}
+		line = line[index:]
+		indexOffset += index
+		indices = append(indices, indexOffset)
+
+		index = bytesutil.IndexOfDoubleSpace(line)
+		if index == -1 {
+			break
+		}
+		line = line[index:]
+		indexOffset += index
+	}
+	return indices
+}

--- a/scanner/tablescan/tablescan_test.go
+++ b/scanner/tablescan/tablescan_test.go
@@ -7,6 +7,20 @@ import (
 	"github.com/kubecolor/kubecolor/testutil"
 )
 
+func TestScanner_emptyLines(t *testing.T) {
+	const input = "\n\n\n"
+
+	s := NewScanner(strings.NewReader(input))
+
+	mustScanCells(t, s)
+	mustScanCells(t, s)
+	mustScanCells(t, s)
+
+	if s.Scan() {
+		t.Fatalf("Expected no more scans, but got: %q", s.Bytes())
+	}
+}
+
 func TestScanner_regularTable(t *testing.T) {
 	const input = "" +
 		"NAME    READY   STATUS      RESTARTS         AGE\n" +
@@ -20,7 +34,26 @@ func TestScanner_regularTable(t *testing.T) {
 	mustScanCells(t, s, "pod-b", "0/1", "Error", "0", "13d")
 
 	if s.Scan() {
-		t.Fatalf("Expected no more scans, but got: %#v", "TODO")
+		t.Fatalf("Expected no more scans, but got: %q", s.Bytes())
+	}
+}
+
+func TestScanner_describeTable(t *testing.T) {
+	const input = "" +
+		"Name    Ready   Status      Restarts         Age\n" +
+		"----    -----   ------      --------         ---\n" +
+		"pod-a   1/1     Running     21 (7d23h ago)   250d\n" +
+		"pod-b   0/1     Error       0                13d\n"
+
+	s := NewScanner(strings.NewReader(input))
+
+	mustScanCells(t, s, "Name", "Ready", "Status", "Restarts", "Age")
+	mustScanCells(t, s, "----", "-----", "------", "--------", "---")
+	mustScanCells(t, s, "pod-a", "1/1", "Running", "21 (7d23h ago)", "250d")
+	mustScanCells(t, s, "pod-b", "0/1", "Error", "0", "13d")
+
+	if s.Scan() {
+		t.Fatalf("Expected no more scans, but got: %q", s.Bytes())
 	}
 }
 
@@ -37,7 +70,7 @@ func TestScanner_emptyCells(t *testing.T) {
 	mustScanCells(t, s, "pod-b", "", "Error", "0", "")
 
 	if s.Scan() {
-		t.Fatalf("Expected no more scans, but got: %#v", "TODO")
+		t.Fatalf("Expected no more scans, but got: %q", s.Bytes())
 	}
 }
 
@@ -62,7 +95,7 @@ func TestScanner_multipleTables(t *testing.T) {
 	mustScanCells(t, s, "deploy-b", "0/1", "0", "0", "13d")
 
 	if s.Scan() {
-		t.Fatalf("Expected no more scans, but got: %#v", "TODO")
+		t.Fatalf("Expected no more scans, but got: %q", s.Bytes())
 	}
 }
 
@@ -87,7 +120,7 @@ func TestScanner_multipleTightlyPackedTables(t *testing.T) {
 	mustScanCells(t, s, "deploy-b", "0/1", "0", "0", "13d")
 
 	if s.Scan() {
-		t.Fatalf("Expected no more scans, but got: %#v", "TODO")
+		t.Fatalf("Expected no more scans, but got: %q", s.Bytes())
 	}
 }
 
@@ -101,10 +134,10 @@ func TestScanner_noHeaderAndEmptyCells(t *testing.T) {
 
 	mustScanCells(t, s, "pod-a", "", "Running", "", "250d")
 	mustScanCells(t, s, "pod-b", "0/1", "", "0", "")
-	mustScanCells(t, s, "pod-c", "0/1", "Error", "0", "13d")
+	mustScanCells(t, s, "pod-c", "2/2", "Error", "0", "13d")
 
 	if s.Scan() {
-		t.Fatalf("Expected no more scans, but got: %#v", "TODO")
+		t.Fatalf("Expected no more scans, but got: %q", s.Bytes())
 	}
 }
 

--- a/scanner/tablescan/tablescan_test.go
+++ b/scanner/tablescan/tablescan_test.go
@@ -1,0 +1,123 @@
+package tablescan
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kubecolor/kubecolor/testutil"
+)
+
+func TestScanner_regularTable(t *testing.T) {
+	const input = "" +
+		"NAME    READY   STATUS      RESTARTS         AGE\n" +
+		"pod-a   1/1     Running     21 (7d23h ago)   250d\n" +
+		"pod-b   0/1     Error       0                13d\n"
+
+	s := NewScanner(strings.NewReader(input))
+
+	mustScanCells(t, s, "NAME", "READY", "STATUS", "RESTARTS", "AGE")
+	mustScanCells(t, s, "pod-a", "1/1", "Running", "21 (7d23h ago)", "250d")
+	mustScanCells(t, s, "pod-b", "0/1", "Error", "0", "13d")
+
+	if s.Scan() {
+		t.Fatalf("Expected no more scans, but got: %#v", "TODO")
+	}
+}
+
+func TestScanner_emptyCells(t *testing.T) {
+	const input = "" +
+		"NAME    READY   STATUS      RESTARTS         AGE\n" +
+		"pod-a   1/1     Running                      250d\n" +
+		"pod-b           Error       0\n"
+
+	s := NewScanner(strings.NewReader(input))
+
+	mustScanCells(t, s, "NAME", "READY", "STATUS", "RESTARTS", "AGE")
+	mustScanCells(t, s, "pod-a", "1/1", "Running", "", "250d")
+	mustScanCells(t, s, "pod-b", "", "Error", "0", "")
+
+	if s.Scan() {
+		t.Fatalf("Expected no more scans, but got: %#v", "TODO")
+	}
+}
+
+func TestScanner_multipleTables(t *testing.T) {
+	const input = "" +
+		"NAME    READY   STATUS      RESTARTS         AGE\n" +
+		"pod-a   1/1     Running     21 (7d23h ago)   250d\n" +
+		"pod-b   0/1     Error       0                13d\n" +
+		"\n" +
+		"NAME       READY   UP-TO-DATE   AVAILABLE   AGE\n" +
+		"deploy-a   1/1     1            1           250d\n" +
+		"deploy-b   0/1     0            0           13d\n"
+
+	s := NewScanner(strings.NewReader(input))
+
+	mustScanCells(t, s, "NAME", "READY", "STATUS", "RESTARTS", "AGE")
+	mustScanCells(t, s, "pod-a", "1/1", "Running", "21 (7d23h ago)", "250d")
+	mustScanCells(t, s, "pod-b", "0/1", "Error", "0", "13d")
+	mustScanCells(t, s) // should detect that headers needs to be recalculated
+	mustScanCells(t, s, "NAME", "READY", "UP-TO-DATE", "AVAILABLE", "AGE")
+	mustScanCells(t, s, "deploy-a", "1/1", "1", "1", "250d")
+	mustScanCells(t, s, "deploy-b", "0/1", "0", "0", "13d")
+
+	if s.Scan() {
+		t.Fatalf("Expected no more scans, but got: %#v", "TODO")
+	}
+}
+
+func TestScanner_multipleTightlyPackedTables(t *testing.T) {
+	const input = "" +
+		"NAME    READY   STATUS      RESTARTS         AGE\n" +
+		"pod-a   1/1     Running     21 (7d23h ago)   250d\n" +
+		"pod-b   0/1     Error       0                13d\n" +
+		"NAME       READY   UP-TO-DATE   AVAILABLE   AGE\n" +
+		"deploy-a   1/1     1            1           250d\n" +
+		"deploy-b   0/1     0            0           13d\n"
+
+	s := NewScanner(strings.NewReader(input))
+
+	mustScanCells(t, s, "NAME", "READY", "STATUS", "RESTARTS", "AGE")
+	mustScanCells(t, s, "pod-a", "1/1", "Running", "21 (7d23h ago)", "250d")
+	mustScanCells(t, s, "pod-b", "0/1", "Error", "0", "13d")
+	// on the next line it should detect that columns are not lining up
+	// and should reevalutate the column indices
+	mustScanCells(t, s, "NAME", "READY", "UP-TO-DATE", "AVAILABLE", "AGE")
+	mustScanCells(t, s, "deploy-a", "1/1", "1", "1", "250d")
+	mustScanCells(t, s, "deploy-b", "0/1", "0", "0", "13d")
+
+	if s.Scan() {
+		t.Fatalf("Expected no more scans, but got: %#v", "TODO")
+	}
+}
+
+func TestScanner_noHeaderAndEmptyCells(t *testing.T) {
+	const input = "" +
+		"pod-a           Running                      250d\n" +
+		"pod-b   0/1                 0\n" +
+		"pod-c   2/2     Error       0                13d\n"
+
+	s := NewScanner(strings.NewReader(input))
+
+	mustScanCells(t, s, "pod-a", "", "Running", "", "250d")
+	mustScanCells(t, s, "pod-b", "0/1", "", "0", "")
+	mustScanCells(t, s, "pod-c", "0/1", "Error", "0", "13d")
+
+	if s.Scan() {
+		t.Fatalf("Expected no more scans, but got: %#v", "TODO")
+	}
+}
+
+func mustScanCells(t *testing.T, s *Scanner, cells ...string) {
+	t.Helper()
+	if !s.Scan() {
+		t.Fatalf("Failed scan; Expected value %q", strings.Join(cells, " | "))
+	}
+
+	var gotCells []string
+	for _, c := range s.Cells() {
+		gotCells = append(gotCells, c.Trimmed)
+	}
+
+	testutil.MustEqual(t, cells, gotCells)
+}


### PR DESCRIPTION
# Description

This PR takes a very similar approach to the describe parser (#21), but has some other hacks such as buffering the tables so that even header-less tables like this has its columns properly indexed:

```
pod-apple            Running                      250d
pod-bear    0/10                 12 (3d ago)
pod-c       2/2      Error       0                13d
```

These lines above are all combined into this:

```
pod-ceare   2/20     Errorng     02 (3d ago)      13dd
```

And then finding columns is run on that combined row.

Some previews of where this PR (as a whole) makes a difference:

| | Get pods (no change) |
| --- | --- |
| Before | ![image](https://github.com/kubecolor/kubecolor/assets/2477952/93c1895c-712d-4a38-ad87-f3a89cd411af)
| After | ![image](https://github.com/kubecolor/kubecolor/assets/2477952/7599fc8e-0773-4703-8522-e3c4d4f973a6)

| | Get pods `--all-namespaces` (column coloring) |
| --- | --- |
| Before | ![image](https://github.com/kubecolor/kubecolor/assets/2477952/c9e559bf-afd2-4cef-aef8-24a8d22b7384)
| After | ![image](https://github.com/kubecolor/kubecolor/assets/2477952/5f25e39c-4637-454b-aa0e-ab5719a5184a)

| | Describe node |
| --- | --- |
| Before | ![image](https://github.com/kubecolor/kubecolor/assets/2477952/7a68e30a-de43-4c48-a813-e874a1a0adc7)
| After | ![image](https://github.com/kubecolor/kubecolor/assets/2477952/bfcd961c-03d4-46bf-9fcb-4dbd4cb5ebe8)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you changed

- Created new scanner: `scanner/tablescan`
- Updated `printer/table.go` to use this scanner
- Copied `bytesutil` from #23
- Changed so "column coloring selection" is shifted when there's a NAMESPACE header (#28)

## Why you think we should change it

The table scanning part was a little buggy, so it needed a rework, similar to the describe parser.

## Related issue (if exists)

Closes #28

