### PR TITLE
DRAFT add a Custom Color variable to change the color schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,53 @@ KUBECOLOR_OBJ_FRESH="1m" kubecolor get po
 
 Default value is `0s`, it means is disabled.
 
+### Change Color Schema
+
+As of version `v0.3.0` it is now possible to use your own color scheme !
+
+To do so, define the environment variable `KUBECOLOR_CUSTOM_COLOR` as a SemiColums (`;`) delimited string, setting one or many of the available keys:
+
+Key      | Description
+---      | --- 
+default  | used when no specific mapping is found for the command
+key      | used to color keys in a `key:value` situation ; value will be either on the following types
+string   | used for single `strings`
+true     |  used when value is `true`
+false    | used when value is `false` or an `error`
+number   | used when the value is a `number`
+null     | used when the value is `null` or a `warning`
+header   | used to print top headers
+fresh    | used for a `delay` or `duration`, like a pod's age
+required |  used when the value is required or is an `error`
+random   | list of comma separated numbers, used to cycle color of each column
+
+
+Use possible color / values from this table (colors may vary depending on your terminal settings, this color chart is just a reference and results may differ)
+
+Color                                           | Value
+---                                             | ---
+Black                                           | 30
+<font color="red">Red</font>                    | 31
+<font color="green">Green</font>                | 32
+<font color="yellow">Yellow</font>              | 33
+<font color="blue">Blue</font>                  | 34
+<font color="magenta">Magenta</font>            | 35
+<font color="cyan">Cyan</font>                  | 36
+<font color="white">White</font>                | 37
+<font color="grey">Light Black ( Grey)</font>   | 90
+<font color="orange">Light Red</font>           | 91
+<font color="lime">Light Green</font>           | 92
+<font color="yellow">Light Yellow</font>        | 93
+<font color="lightblue">Light Blue</font>       | 94
+<font color="pink">Light Magenta</font>         | 95
+<font color="aquamarine">Light Cyan</font>      | 96
+<font color="silver">Light White (White)</font> | 97
+
+Ex:
+```bash
+export KUBECOLOR_CUSTOM_COLOR="default:32;key:36;string:37;true:32;false:31;number:35;null:33;header:37;fresh:32;required:31;random:36,37"
+```
+
 ## Supported kubectl version
 
 Because kubecolor internally calls `kubectl` command, if you are using unsupported kubectl version, it's also not supported by kubecolor.

--- a/color/color.go
+++ b/color/color.go
@@ -17,6 +17,15 @@ const (
 	Magenta
 	Cyan
 	White
+
+	LightBlack Color = iota + 90 // Grey...
+	LightRed
+	LightGreen
+	LightYellow
+	LightBlue
+	LightMagenta
+	LightCyan
+	LightWhite // White...
 )
 
 func (c Color) sequence() int {

--- a/command/config.go
+++ b/command/config.go
@@ -3,7 +3,12 @@ package command
 import (
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"time"
+
+	"github.com/kubecolor/kubecolor/color"
+	"github.com/kubecolor/kubecolor/printer"
 )
 
 type KubecolorConfig struct {
@@ -13,6 +18,7 @@ type KubecolorConfig struct {
 	ShowKubecolorVersion bool
 	KubectlCmd           string
 	ObjFreshThreshold    time.Duration
+	ColorSchema          printer.ColorSchema
 }
 
 func ResolveConfig(args []string) ([]string, *KubecolorConfig) {
@@ -40,6 +46,67 @@ func ResolveConfig(args []string) ([]string, *KubecolorConfig) {
 		}
 	}
 
+	// Parse the color schema if provided
+	// format is like "default:32;key:36;string:37;true:32;false:31;number:35;null:33;header:37;fresh:32;required:31;random:36,37"
+	ColorSchema := printer.NewColorSchema(darkBackground)
+	customColorEnv := "KUBECOLOR_CUSTOM_COLOR"
+	if customColor := os.Getenv(customColorEnv); customColor != "" {
+		customSelections := strings.Split(customColor, ";")
+		for _, customSelection := range customSelections {
+			keyVal := strings.Split(customSelection, ":")
+			if len(keyVal) != 2 {
+				fmt.Printf("[WARN] [kubecolor] cannot parse custom color selection taken from env %s. See kubecolor docs.\n", customSelection)
+				break
+			}
+
+			// Check the random case as the value if a list
+			if keyVal[0] == "random" {
+				rndColors := strings.Split(keyVal[1], ",")
+				for _, newColor := range rndColors {
+					val, err := strconv.Atoi(newColor)
+					if err != nil {
+						fmt.Printf("[WARN] [kubecolor] cannot parse custom color taken from env %s. See kubecolor document. %v\n", customSelection, err)
+						break
+					}
+					ColorSchema.RandomColor = append(ColorSchema.RandomColor, color.Color(val))
+				}
+				continue
+			}
+
+			key := keyVal[0]
+			val, err := strconv.Atoi(keyVal[1])
+			if err != nil {
+				fmt.Printf("[WARN] [kubecolor] cannot parse custom color taken from env %s. See kubecolor document. %v\n", customSelection, err)
+				break
+			}
+			colorName := color.Color(val)
+
+			switch key {
+			case "default":
+				ColorSchema.DefaultColor = colorName
+			case "key":
+				ColorSchema.KeyColor = colorName
+			case "string":
+				ColorSchema.StringColor = colorName
+			case "true":
+				ColorSchema.TrueColor = colorName
+			case "false":
+				ColorSchema.FalseColor = colorName
+			case "number":
+				ColorSchema.NumberColor = colorName
+			case "null":
+				ColorSchema.NumberColor = colorName
+			case "header":
+				ColorSchema.HeaderColor = colorName
+			case "fresh":
+				ColorSchema.NumberColor = colorName
+			case "required":
+				ColorSchema.RequiredColor = colorName
+			default:
+			}
+		}
+	}
+
 	return args, &KubecolorConfig{
 		Plain:                plainFlagFound,
 		DarkBackground:       darkBackground,
@@ -47,6 +114,7 @@ func ResolveConfig(args []string) ([]string, *KubecolorConfig) {
 		ShowKubecolorVersion: kubecolorVersionFlagFound,
 		KubectlCmd:           kubectlCmd,
 		ObjFreshThreshold:    objFreshAgeThresholdDuration,
+		ColorSchema:          ColorSchema,
 	}
 }
 

--- a/command/runner.go
+++ b/command/runner.go
@@ -27,21 +27,22 @@ type Printers struct {
 }
 
 // This is defined here to be replaced in test
-var getPrinters = func(subcommandInfo *kubectl.SubcommandInfo, darkBackground bool, objFreshThreshold time.Duration) *Printers {
+var getPrinters = func(subcommandInfo *kubectl.SubcommandInfo, darkBackground bool, objFreshThreshold time.Duration, ColorSchema printer.ColorSchema) *Printers {
 	return &Printers{
 		FullColoredPrinter: &printer.KubectlOutputColoredPrinter{
 			SubcommandInfo:    subcommandInfo,
 			DarkBackground:    darkBackground,
 			Recursive:         subcommandInfo.Recursive,
 			ObjFreshThreshold: objFreshThreshold,
+			ColorSchema:       ColorSchema,
 		},
 		ErrorPrinter: &printer.WithFuncPrinter{
 			Fn: func(line string) color.Color {
 				if strings.HasPrefix(strings.ToLower(line), "error") {
-					return color.Red
+					return ColorSchema.RequiredColor
 				}
 
-				return color.Yellow
+				return ColorSchema.StringColor
 			},
 		},
 	}
@@ -94,7 +95,7 @@ func Run(args []string, version string) error {
 		return err
 	}
 
-	printers := getPrinters(subcommandInfo, config.DarkBackground, config.ObjFreshThreshold)
+	printers := getPrinters(subcommandInfo, config.DarkBackground, config.ObjFreshThreshold, config.ColorSchema)
 
 	wg := &sync.WaitGroup{}
 

--- a/printer/colors_definition.go
+++ b/printer/colors_definition.go
@@ -38,3 +38,51 @@ var (
 	HeaderColorForLight   = color.Black // for plain table
 	RequiredColorForLight = color.Red   // for `kubectl explain`
 )
+
+type ColorSchema struct {
+	DefaultColor, // defaut when no specific mapping is found for the command
+	KeyColor, // used to color keys (where ?)
+	StringColor, // default color for strings
+	TrueColor, // used when value is true
+	FalseColor, // used when value is false or an error
+	NumberColor, // used when the value is a number
+	NullColor, // used when the value is null or a warning
+	HeaderColor, // used to print headers
+	FreshColor, // color used when the time value is under a certain delay
+	RequiredColor color.Color // used when the value is required or is an error
+	RandomColor []color.Color // used to display multiple colons, cycle between colors
+}
+
+// newColorSchema returns the color schema depending on the chosen theme
+func NewColorSchema(dark bool) ColorSchema {
+
+	if dark {
+		return ColorSchema{
+			DefaultColor:  color.Yellow,
+			KeyColor:      color.Cyan,
+			StringColor:   color.White,
+			TrueColor:     color.Green,
+			FalseColor:    color.Red,
+			NumberColor:   color.Magenta,
+			NullColor:     color.Yellow,
+			HeaderColor:   color.White,
+			FreshColor:    color.Green,
+			RequiredColor: color.Red,
+			RandomColor:   []color.Color{color.White, color.Cyan},
+		}
+	}
+
+	return ColorSchema{
+		DefaultColor:  color.Yellow,
+		KeyColor:      color.Blue,
+		StringColor:   color.Black,
+		TrueColor:     color.Green,
+		FalseColor:    color.Red,
+		NumberColor:   color.Magenta,
+		NullColor:     color.Yellow,
+		HeaderColor:   color.Black,
+		FreshColor:    color.Green,
+		RequiredColor: color.Red,
+		RandomColor:   []color.Color{color.Black, color.Blue},
+	}
+}

--- a/printer/format.go
+++ b/printer/format.go
@@ -13,50 +13,32 @@ func toSpaces(n int) string {
 
 // getColorByKeyIndent returns a color based on the given indent.
 // When you want to change key color based on indent depth (e.g. Json, Yaml), use this function
-func getColorByKeyIndent(indent int, basicIndentWidth int, dark bool) color.Color {
+func getColorByKeyIndent(indent int, basicIndentWidth int, schema ColorSchema) color.Color {
 	switch indent / basicIndentWidth % 2 {
 	case 1:
-		if dark {
-			return color.White
-		}
-		return color.Black
+		return schema.StringColor
 	default:
-		return color.Yellow
+		return schema.DefaultColor
 	}
 }
 
 // getColorByValueType returns a color by value.
 // This is intended to be used to colorize any structured data e.g. Json, Yaml.
-func getColorByValueType(val string, dark bool) color.Color {
+func getColorByValueType(val string, schema ColorSchema) color.Color {
 	switch val {
 	case "null", "<none>", "<unknown>", "<unset>":
-		if dark {
-			return NullColorForDark
-		}
-		return NullColorForLight
+		return schema.NullColor
 	case "true", "True":
-		if dark {
-			return TrueColorForDark
-		}
-		return TrueColorForLight
+		return schema.TrueColor
 	case "false", "False":
-		if dark {
-			return FalseColorForDark
-		}
-		return FalseColorForLight
+		return schema.FalseColor
 	}
 
 	if isOnlyDigits(val) {
-		if dark {
-			return NumberColorForDark
-		}
-		return NumberColorForLight
+		return schema.NumberColor
 	}
 
-	if dark {
-		return StringColorForDark
-	}
-	return StringColorForLight
+	return schema.StringColor
 }
 
 func isOnlyDigits(s string) bool {
@@ -73,22 +55,22 @@ func isDigit(r rune) bool {
 }
 
 // getColorsByBackground returns a preset of colors depending on given background color
-func getColorsByBackground(dark bool) []color.Color {
-	if dark {
-		return colorsForDarkBackground
-	}
+// func getColorsByBackground(dark bool) []color.Color {
+// 	if dark {
+// 		return colorsForDarkBackground
+// 	}
 
-	return colorsForLightBackground
-}
+// 	return colorsForLightBackground
+// }
 
 // getHeaderColorByBackground returns a defined color for Header (not actual data) by the background color
-func getHeaderColorByBackground(dark bool) color.Color {
-	if dark {
-		return HeaderColorForDark
-	}
+// func getHeaderColorByBackground(dark bool) color.Color {
+// 	if dark {
+// 		return HeaderColorForDark
+// 	}
 
-	return HeaderColorForLight
-}
+// 	return HeaderColorForLight
+// }
 
 // findIndent returns a length of indent (spaces at left) in the given line
 func findIndent(line string) int {

--- a/printer/format_test.go
+++ b/printer/format_test.go
@@ -3,7 +3,6 @@ package printer
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/kubecolor/kubecolor/color"
 )
 
@@ -30,7 +29,7 @@ func Test_getColorByKeyIndent(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := getColorByKeyIndent(tt.indent, tt.basicIndentWidth, tt.dark)
+			got := getColorByKeyIndent(tt.indent, tt.basicIndentWidth, NewColorSchema(tt.dark))
 			if got != tt.expected {
 				t.Errorf("fail: got: %v, expected: %v", got, tt.expected)
 			}
@@ -64,7 +63,7 @@ func Test_getColorByValueType(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := getColorByValueType(tt.val, tt.dark)
+			got := getColorByValueType(tt.val, NewColorSchema(tt.dark))
 			if got != tt.expected {
 				t.Errorf("fail: got: %v, expected: %v", got, tt.expected)
 			}
@@ -72,47 +71,47 @@ func Test_getColorByValueType(t *testing.T) {
 	}
 }
 
-func Test_getColorsByBackground(t *testing.T) {
-	tests := []struct {
-		name     string
-		dark     bool
-		expected []color.Color
-	}{
-		{"dark", true, colorsForDarkBackground},
-		{"light", false, colorsForLightBackground},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := getColorsByBackground(tt.dark)
-			if diff := cmp.Diff(got, tt.expected); diff != "" {
-				t.Errorf("fail: %v", diff)
-			}
-		})
-	}
-}
+// func Test_getColorsByBackground(t *testing.T) {
+// 	tests := []struct {
+// 		name     string
+// 		dark     bool
+// 		expected []color.Color
+// 	}{
+// 		{"dark", true, colorsForDarkBackground},
+// 		{"light", false, colorsForLightBackground},
+// 	}
+// 	for _, tt := range tests {
+// 		tt := tt
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			t.Parallel()
+// 			got := getColorsByBackground(tt.dark)
+// 			if diff := cmp.Diff(got, tt.expected); diff != "" {
+// 				t.Errorf("fail: %v", diff)
+// 			}
+// 		})
+// 	}
+// }
 
-func Test_getHeaderColorByBackground(t *testing.T) {
-	tests := []struct {
-		name     string
-		dark     bool
-		expected color.Color
-	}{
-		{"dark", true, HeaderColorForDark},
-		{"light", false, HeaderColorForLight},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := getHeaderColorByBackground(tt.dark)
-			if got != tt.expected {
-				t.Errorf("fail: got: %v, expected: %v", got, tt.expected)
-			}
-		})
-	}
-}
+// func Test_getHeaderColorByBackground(t *testing.T) {
+// 	tests := []struct {
+// 		name     string
+// 		dark     bool
+// 		expected color.Color
+// 	}{
+// 		{"dark", true, HeaderColorForDark},
+// 		{"light", false, HeaderColorForLight},
+// 	}
+// 	for _, tt := range tests {
+// 		tt := tt
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			t.Parallel()
+// 			got := getHeaderColorByBackground(tt.dark)
+// 			if got != tt.expected {
+// 				t.Errorf("fail: got: %v, expected: %v", got, tt.expected)
+// 			}
+// 		})
+// 	}
+// }
 
 func Test_findIndent(t *testing.T) {
 	tests := []struct {

--- a/printer/json.go
+++ b/printer/json.go
@@ -11,17 +11,18 @@ import (
 
 type JsonPrinter struct {
 	DarkBackground bool
+	ColorSchema    ColorSchema
 }
 
 func (jp *JsonPrinter) Print(r io.Reader, w io.Writer) {
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		line := scanner.Text()
-		printLineAsJsonFormat(line, w, jp.DarkBackground)
+		printLineAsJsonFormat(line, w, jp.DarkBackground, jp.ColorSchema)
 	}
 }
 
-func printLineAsJsonFormat(line string, w io.Writer, dark bool) {
+func printLineAsJsonFormat(line string, w io.Writer, dark bool, colorSchema ColorSchema) {
 	indentCnt := findIndent(line)
 	indent := toSpaces(indentCnt)
 	trimmedLine := strings.TrimLeft(line, " ")
@@ -55,18 +56,18 @@ func printLineAsJsonFormat(line string, w io.Writer, dark bool) {
 
 	if len(splitted) == 1 {
 		// when coming here, it will be a value in an array
-		fmt.Fprintf(w, "%s%s\n", indent, toColorizedJsonValue(splitted[0], dark))
+		fmt.Fprintf(w, "%s%s\n", indent, toColorizedJsonValue(splitted[0], colorSchema))
 		return
 	}
 
 	key := splitted[0]
 	val := splitted[1]
 
-	fmt.Fprintf(w, "%s%s: %s\n", indent, toColorizedJsonKey(key, indentCnt, 4, dark), toColorizedJsonValue(val, dark))
+	fmt.Fprintf(w, "%s%s: %s\n", indent, toColorizedJsonKey(key, indentCnt, 4, colorSchema), toColorizedJsonValue(val, colorSchema))
 }
 
 // toColorizedJsonKey returns colored json key
-func toColorizedJsonKey(key string, indentCnt, basicWidth int, dark bool) string {
+func toColorizedJsonKey(key string, indentCnt, basicWidth int, colorSchema ColorSchema) string {
 	hasColon := strings.HasSuffix(key, ":")
 	// remove colon and double quotations although they might not exist actually
 	key = strings.TrimRight(key, ":")
@@ -77,13 +78,13 @@ func toColorizedJsonKey(key string, indentCnt, basicWidth int, dark bool) string
 		format += ":"
 	}
 
-	return fmt.Sprintf(format, color.Apply(doubleQuoteTrimmed, getColorByKeyIndent(indentCnt, basicWidth, dark)))
+	return fmt.Sprintf(format, color.Apply(doubleQuoteTrimmed, getColorByKeyIndent(indentCnt, basicWidth, colorSchema)))
 }
 
 // toColorizedJsonValue returns colored json value.
 // This function checks it trailing comma and double quotation exist
 // then colorize the given value considering them.
-func toColorizedJsonValue(value string, dark bool) string {
+func toColorizedJsonValue(value string, colorSchema ColorSchema) string {
 	if value == "{" {
 		return "{"
 	}
@@ -119,5 +120,5 @@ func toColorizedJsonValue(value string, dark bool) string {
 		format = `%s`
 	}
 
-	return fmt.Sprintf(format, color.Apply(doubleQuoteTrimmedValue, getColorByValueType(value, dark)))
+	return fmt.Sprintf(format, color.Apply(doubleQuoteTrimmedValue, getColorByValueType(value, colorSchema)))
 }

--- a/printer/kubectl_describe.go
+++ b/printer/kubectl_describe.go
@@ -40,7 +40,7 @@ func (dp *DescribePrinter) Print(r io.Reader, w io.Writer) {
 
 		fmt.Fprintf(w, "%s", line.Indent)
 		if len(line.Key) > 0 {
-			keyColor := getColorByKeyIndent(line.KeyIndent(), basicIndentWidth, dp.DarkBackground)
+			keyColor := getColorByKeyIndent(line.KeyIndent(), basicIndentWidth, dp.TablePrinter.ColorSchema)
 			key := string(line.Key)
 			if withoutColon, ok := strings.CutSuffix(key, ":"); ok {
 				fmt.Fprint(w, color.Apply(withoutColon, keyColor), ":")
@@ -62,11 +62,11 @@ func (dp *DescribePrinter) Print(r io.Reader, w io.Writer) {
 
 func (dp *DescribePrinter) valueColor(path describe.Path, value string) color.Color {
 	if describeUseStatusColoring(path) {
-		if col, ok := ColorStatus(value); ok {
+		if col, ok := ColorStatus(value, dp.TablePrinter.ColorSchema); ok {
 			return col
 		}
 	}
-	return getColorByValueType(value, dp.DarkBackground)
+	return getColorByValueType(value, dp.TablePrinter.ColorSchema)
 }
 
 var describePathsToColor = []*regexp.Regexp{

--- a/printer/kubectl_describe_test.go
+++ b/printer/kubectl_describe_test.go
@@ -67,7 +67,7 @@ func Test_DescribePrinter_Print(t *testing.T) {
 		{
 			name:           "table format in kubectl describe can be colored by describe",
 			darkBackground: true,
-			tablePrinter:   NewTablePrinter(false, true, nil),
+			tablePrinter:   NewTablePrinter(false, true, ColorSchema{}, nil),
 			input: testutil.NewHereDoc(`
 				Conditions:
 				  Type             Status  LastHeartbeatTime                 LastTransitionTime                Reason                       Message

--- a/printer/kubectl_explain.go
+++ b/printer/kubectl_explain.go
@@ -13,6 +13,7 @@ import (
 // ExplainPrinter is a specific printer to print kubectl explain format.
 type ExplainPrinter struct {
 	DarkBackground bool
+	ColorSchema    ColorSchema
 	Recursive      bool
 }
 
@@ -42,21 +43,17 @@ func (ep *ExplainPrinter) Print(r io.Reader, w io.Writer) {
 
 func (ep *ExplainPrinter) keyColor(line describe.Line, isFields bool) color.Color {
 	if ep.Recursive && isFields {
-		return getColorByKeyIndent(line.KeyIndent(), 2, ep.DarkBackground)
+		return getColorByKeyIndent(line.KeyIndent(), 2, ep.ColorSchema)
 	}
 
-	return getColorByKeyIndent(0, 2, ep.DarkBackground)
+	return getColorByKeyIndent(0, 2, ep.ColorSchema)
 }
 
 func (ep *ExplainPrinter) printVal(w io.Writer, val string) {
 	const suffix = "-required-"
 	if withoutSuffix, ok := strings.CutSuffix(val, suffix); ok {
 		fmt.Fprint(w, withoutSuffix)
-		if ep.DarkBackground {
-			fmt.Fprint(w, color.Apply(suffix, RequiredColorForDark))
-		} else {
-			fmt.Fprint(w, color.Apply(suffix, RequiredColorForLight))
-		}
+		fmt.Fprint(w, color.Apply(suffix, ep.ColorSchema.RequiredColor))
 		return
 	}
 	fmt.Fprint(w, val)

--- a/printer/kubectl_options.go
+++ b/printer/kubectl_options.go
@@ -10,7 +10,7 @@ import (
 )
 
 type OptionsPrinter struct {
-	DarkBackground bool
+	ColorSchema ColorSchema
 }
 
 func (op *OptionsPrinter) Print(r io.Reader, w io.Writer) {
@@ -25,7 +25,7 @@ func (op *OptionsPrinter) Print(r io.Reader, w io.Writer) {
 		}
 
 		if isFirstLine {
-			fmt.Fprintf(w, "%s\n", color.Apply(line, op.firstLineColor()))
+			fmt.Fprintf(w, "%s\n", color.Apply(line, op.ColorSchema.StringColor))
 			isFirstLine = false
 			continue
 		}
@@ -37,14 +37,6 @@ func (op *OptionsPrinter) Print(r io.Reader, w io.Writer) {
 		splitted := strings.SplitN(trimmedLine, ": ", 2)
 		key, val := splitted[0], splitted[1]
 
-		fmt.Fprintf(w, "%s%s: %s\n", indent, color.Apply(key, getColorByKeyIndent(0, 2, op.DarkBackground)), color.Apply(val, getColorByValueType(val, op.DarkBackground)))
+		fmt.Fprintf(w, "%s%s: %s\n", indent, color.Apply(key, getColorByKeyIndent(0, 2, op.ColorSchema)), color.Apply(val, getColorByValueType(val, op.ColorSchema)))
 	}
-}
-
-func (op *OptionsPrinter) firstLineColor() color.Color {
-	if op.DarkBackground {
-		return StringColorForDark
-	}
-
-	return StringColorForLight
 }

--- a/printer/kubectl_options_test.go
+++ b/printer/kubectl_options_test.go
@@ -10,14 +10,14 @@ import (
 
 func Test_OptionsPrinter_Print(t *testing.T) {
 	tests := []struct {
-		name           string
-		darkBackground bool
-		input          string
-		expected       string
+		name        string
+		colorSchema ColorSchema
+		input       string
+		expected    string
 	}{
 		{
-			name:           "successful",
-			darkBackground: true,
+			name:        "successful",
+			colorSchema: NewColorSchema(true),
 			input: testutil.NewHereDoc(`
 				The following options can be passed to any command:
 
@@ -56,7 +56,7 @@ func Test_OptionsPrinter_Print(t *testing.T) {
 			t.Parallel()
 			r := strings.NewReader(tt.input)
 			var w bytes.Buffer
-			printer := OptionsPrinter{DarkBackground: tt.darkBackground}
+			printer := OptionsPrinter{ColorSchema: tt.colorSchema}
 			printer.Print(r, &w)
 			testutil.MustEqual(t, tt.expected, w.String())
 		})

--- a/printer/kubectl_version.go
+++ b/printer/kubectl_version.go
@@ -11,6 +11,7 @@ import (
 
 type VersionShortPrinter struct {
 	DarkBackground bool
+	ColorSchema    ColorSchema
 }
 
 // kubectl version --short format
@@ -23,14 +24,15 @@ func (vsp *VersionShortPrinter) Print(r io.Reader, w io.Writer) {
 		splitted := strings.Split(line, ": ")
 		key, val := splitted[0], splitted[1]
 		fmt.Fprintf(w, "%s: %s\n",
-			color.Apply(key, getColorByKeyIndent(0, 2, vsp.DarkBackground)),
-			color.Apply(val, getColorByValueType(val, vsp.DarkBackground)),
+			color.Apply(key, getColorByKeyIndent(0, 2, vsp.ColorSchema)),
+			color.Apply(val, getColorByValueType(val, vsp.ColorSchema)),
 		)
 	}
 }
 
 type VersionPrinter struct {
 	DarkBackground bool
+	ColorSchema    ColorSchema
 }
 
 func (vp *VersionPrinter) Print(r io.Reader, w io.Writer) {
@@ -39,7 +41,7 @@ func (vp *VersionPrinter) Print(r io.Reader, w io.Writer) {
 		line := scanner.Text()
 		splitted := strings.SplitN(line, ": ", 2)
 		key, val := splitted[0], splitted[1]
-		key = color.Apply(key, getColorByKeyIndent(0, 2, vp.DarkBackground))
+		key = color.Apply(key, getColorByKeyIndent(0, 2, vp.ColorSchema))
 
 		// val is go struct like
 		// version.Info{Major:"1", Minor:"19", GitVersion:"v1.19.2", GitCommit:"f5743093fd1c663cb0cbc89748f730662345d44d", GitTreeState:"clean", BuildDate:"2020-09-16T13:32:58Z", GoVersion:"go1.15", Compiler:"gc", Platform:"linux/amd64"}
@@ -51,15 +53,15 @@ func (vp *VersionPrinter) Print(r io.Reader, w io.Writer) {
 		values := strings.Split(pkgAndValues[1], ", ")
 		coloredValues := make([]string, len(values))
 
-		fmt.Fprintf(w, "%s: %s{", key, color.Apply(packageName, getColorByKeyIndent(2, 2, vp.DarkBackground)))
+		fmt.Fprintf(w, "%s: %s{", key, color.Apply(packageName, getColorByKeyIndent(2, 2, vp.ColorSchema)))
 		for i, value := range values {
 			kv := strings.SplitN(value, ":", 2)
-			coloredKey := color.Apply(kv[0], getColorByKeyIndent(0, 2, vp.DarkBackground))
+			coloredKey := color.Apply(kv[0], getColorByKeyIndent(0, 2, vp.ColorSchema))
 
 			isValDoubleQuotationSurrounded := strings.HasPrefix(kv[1], `"`) && strings.HasSuffix(kv[1], `"`)
 			val := strings.TrimRight(strings.TrimLeft(kv[1], `"`), `"`)
 
-			coloredVal := color.Apply(val, getColorByValueType(kv[1], vp.DarkBackground))
+			coloredVal := color.Apply(val, getColorByValueType(kv[1], vp.ColorSchema))
 
 			if isValDoubleQuotationSurrounded {
 				coloredValues[i] = fmt.Sprintf(`%s:"%s"`, coloredKey, coloredVal)

--- a/printer/single_colored_printer.go
+++ b/printer/single_colored_printer.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kubecolor/kubecolor/color"
 )
 
-// SingleColoredPrinter is a printer to print something in pre-cofigured color.
+// SingleColoredPrinter is a printer to print something in pre-configured color.
 type SingleColoredPrinter struct {
 	Color color.Color
 }

--- a/printer/table.go
+++ b/printer/table.go
@@ -18,15 +18,17 @@ type tableColumnColor struct {
 type TablePrinter struct {
 	WithHeader     bool
 	DarkBackground bool
+	ColorSchema    ColorSchema
 	ColorDeciderFn func(index int, column string) (color.Color, bool)
 
 	hasLeadingNamespaceColumn bool
 }
 
-func NewTablePrinter(withHeader, darkBackground bool, colorDeciderFn func(index int, column string) (color.Color, bool)) *TablePrinter {
+func NewTablePrinter(withHeader, darkBackground bool, colorSchema ColorSchema, colorDeciderFn func(index int, column string) (color.Color, bool)) *TablePrinter {
 	return &TablePrinter{
 		WithHeader:     withHeader,
 		DarkBackground: darkBackground,
+		ColorSchema:    colorSchema,
 		ColorDeciderFn: colorDeciderFn,
 	}
 }
@@ -42,7 +44,7 @@ func (tp *TablePrinter) Print(r io.Reader, w io.Writer) {
 		}
 		if (tp.WithHeader && isFirstLine) || isAllCellsUpper(cells) {
 			isFirstLine = false
-			fmt.Fprintf(w, "%s\n", color.Apply(scanner.Text(), getHeaderColorByBackground(tp.DarkBackground)))
+			fmt.Fprintf(w, "%s\n", color.Apply(scanner.Text(), tp.ColorSchema.HeaderColor))
 
 			if strings.EqualFold(cells[0].Trimmed, "namespace") {
 				tp.hasLeadingNamespaceColumn = true
@@ -51,7 +53,7 @@ func (tp *TablePrinter) Print(r io.Reader, w io.Writer) {
 		}
 
 		fmt.Fprintf(w, "%s", scanner.LeadingSpaces())
-		tp.printLineAsTableFormat(w, cells, getColorsByBackground(tp.DarkBackground))
+		tp.printLineAsTableFormat(w, cells, tp.ColorSchema.RandomColor)
 	}
 }
 

--- a/printer/table_test.go
+++ b/printer/table_test.go
@@ -16,6 +16,7 @@ func Test_TablePrinter_Print(t *testing.T) {
 		colorDeciderFn func(index int, column string) (color.Color, bool)
 		withHeader     bool
 		darkBackground bool
+		colorSchema    ColorSchema
 		input          string
 		expected       string
 	}{
@@ -24,6 +25,7 @@ func Test_TablePrinter_Print(t *testing.T) {
 			colorDeciderFn: nil,
 			withHeader:     true,
 			darkBackground: true,
+			colorSchema:    ColorSchema{},
 			input: testutil.NewHereDoc(`
 				NAME          READY   STATUS    RESTARTS   AGE
 				nginx-dnmv5   1/1     Running   0          6d6h
@@ -41,6 +43,7 @@ func Test_TablePrinter_Print(t *testing.T) {
 			colorDeciderFn: nil,
 			withHeader:     true,
 			darkBackground: true,
+			colorSchema:    ColorSchema{},
 			input: testutil.NewHereDoc(`
 				NAME                         READY   STATUS    RESTARTS   AGE
 				pod/nginx-8spn9              1/1     Running   1          19d
@@ -67,6 +70,7 @@ func Test_TablePrinter_Print(t *testing.T) {
 			colorDeciderFn: nil,
 			withHeader:     false,
 			darkBackground: true,
+			colorSchema:    ColorSchema{},
 			input: testutil.NewHereDoc(`
 				nginx-dnmv5   1/1     Running   0          6d6h
 				nginx-m8pbc   1/1     Running   0          6d6h
@@ -82,6 +86,7 @@ func Test_TablePrinter_Print(t *testing.T) {
 			colorDeciderFn: nil,
 			withHeader:     true,
 			darkBackground: false,
+			colorSchema:    ColorSchema{},
 			input: testutil.NewHereDoc(`
 				NAME          READY   STATUS    RESTARTS   AGE
 				nginx-dnmv5   1/1     Running   0          6d6h
@@ -117,6 +122,7 @@ func Test_TablePrinter_Print(t *testing.T) {
 			},
 			withHeader:     true,
 			darkBackground: true,
+			colorSchema:    ColorSchema{},
 			// "CrashLoopBackOff" will be red, "0/1" will be yellow
 			input: testutil.NewHereDoc(`
 				NAME          READY   STATUS             RESTARTS   AGE
@@ -135,6 +141,7 @@ func Test_TablePrinter_Print(t *testing.T) {
 			colorDeciderFn: nil,
 			withHeader:     true,
 			darkBackground: true,
+			colorSchema:    ColorSchema{},
 			input: testutil.NewHereDoc(`
 				NAME                              SHORTNAMES   APIGROUP                       NAMESPACED   KIND
 				bindings                                                                      true         Binding
@@ -179,7 +186,7 @@ func Test_TablePrinter_Print(t *testing.T) {
 			t.Parallel()
 			r := strings.NewReader(tt.input)
 			var w bytes.Buffer
-			printer := NewTablePrinter(tt.withHeader, tt.darkBackground, tt.colorDeciderFn)
+			printer := NewTablePrinter(tt.withHeader, tt.darkBackground, tt.colorSchema, tt.colorDeciderFn)
 			printer.Print(r, &w)
 			testutil.MustEqual(t, tt.expected, w.String())
 		})

--- a/printer/yaml.go
+++ b/printer/yaml.go
@@ -11,8 +11,8 @@ import (
 
 type YamlPrinter struct {
 	DarkBackground bool
-
-	inString bool
+	ColorSchema    ColorSchema
+	inString       bool
 }
 
 func (yp *YamlPrinter) Print(r io.Reader, w io.Writer) {
@@ -30,7 +30,7 @@ func (yp *YamlPrinter) printLineAsYamlFormat(line string, w io.Writer, dark bool
 
 	if yp.inString {
 		// if inString is true, the line must be a part of a string which is broken into several lines
-		fmt.Fprintf(w, "%s%s\n", indent, yp.toColorizedStringValue(trimmedLine, dark))
+		fmt.Fprintf(w, "%s%s\n", indent, yp.toColorizedStringValue(trimmedLine))
 		yp.inString = !yp.isStringClosed(trimmedLine)
 		return
 	}
@@ -40,7 +40,7 @@ func (yp *YamlPrinter) printLineAsYamlFormat(line string, w io.Writer, dark bool
 	if len(splitted) == 2 {
 		// key: value
 		key, val := splitted[0], splitted[1]
-		fmt.Fprintf(w, "%s%s: %s\n", indent, yp.toColorizedYamlKey(key, indentCnt, 2, dark), yp.toColorizedYamlValue(val, dark))
+		fmt.Fprintf(w, "%s%s: %s\n", indent, yp.toColorizedYamlKey(key, indentCnt, 2, dark), yp.toColorizedYamlValue(val))
 		yp.inString = yp.isStringOpenedButNotClosed(val)
 		return
 	}
@@ -52,7 +52,7 @@ func (yp *YamlPrinter) printLineAsYamlFormat(line string, w io.Writer, dark bool
 		return
 	}
 
-	fmt.Fprintf(w, "%s%s\n", indent, yp.toColorizedYamlValue(splitted[0], dark))
+	fmt.Fprintf(w, "%s%s\n", indent, yp.toColorizedYamlValue(splitted[0]))
 }
 
 func (yp *YamlPrinter) toColorizedYamlKey(key string, indentCnt, basicWidth int, dark bool) string {
@@ -71,10 +71,10 @@ func (yp *YamlPrinter) toColorizedYamlKey(key string, indentCnt, basicWidth int,
 		indentCnt += 2
 	}
 
-	return fmt.Sprintf(format, color.Apply(key, getColorByKeyIndent(indentCnt, basicWidth, dark)))
+	return fmt.Sprintf(format, color.Apply(key, getColorByKeyIndent(indentCnt, basicWidth, yp.ColorSchema)))
 }
 
-func (yp *YamlPrinter) toColorizedYamlValue(value string, dark bool) string {
+func (yp *YamlPrinter) toColorizedYamlValue(value string) string {
 	if value == "{}" {
 		return "{}"
 	}
@@ -97,14 +97,10 @@ func (yp *YamlPrinter) toColorizedYamlValue(value string, dark bool) string {
 		format = "%s"
 	}
 
-	return fmt.Sprintf(format, color.Apply(trimmedValue, getColorByValueType(value, dark)))
+	return fmt.Sprintf(format, color.Apply(trimmedValue, getColorByValueType(value, yp.ColorSchema)))
 }
 
-func (yp *YamlPrinter) toColorizedStringValue(value string, dark bool) string {
-	c := StringColorForLight
-	if dark {
-		c = StringColorForDark
-	}
+func (yp *YamlPrinter) toColorizedStringValue(value string) string {
 
 	isDoubleQuoted := strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`)
 	trimmedValue := strings.TrimRight(strings.TrimLeft(value, `"`), `"`)
@@ -116,7 +112,7 @@ func (yp *YamlPrinter) toColorizedStringValue(value string, dark bool) string {
 	default:
 		format = "%s"
 	}
-	return fmt.Sprintf(format, color.Apply(trimmedValue, c))
+	return fmt.Sprintf(format, color.Apply(trimmedValue, yp.ColorSchema.StringColor))
 }
 
 func (yp *YamlPrinter) isStringClosed(line string) bool {


### PR DESCRIPTION
# Description

This PR adds a new env variable `KUBECOLOR_CUSTOM_COLOR` which allows to change the color schema used by `kubecolor`.

With this, we can get rid of the `dark` or `light` arguments in most of the functions. We still use the `--light-background` command line flag to change the default color schema, which in turn provides the same behaviour.

There's still some refactoring to do and a lot of cleanup, including exported variables that don't have to...

As of now it should be a non-breaking features as the default color scheme remain the same.

see Readme.md file for more details

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you changed

Almost every call to any function that makes a color decision was changed. 

## Why you think we should change it

This is a long requested features, and will allow to any kind of color-disability to customize the colors to best help the `kubectl` reading.

## Related issue (if exists)

https://github.com/kubecolor/kubecolor/issues/9
