### PR TITLE
fix hard coded color for help messages

### DIFF
--- a/printer/kubectl_output_colored_printer.go
+++ b/printer/kubectl_output_colored_printer.go
@@ -239,7 +239,11 @@ func (kp *KubectlOutputColoredPrinter) Print(r io.Reader, w io.Writer) {
 	}
 
 	if kp.SubcommandInfo.Help {
-		printer = &SingleColoredPrinter{Color: color.White}
+		stringColor := StringColorForDark
+		if !kp.DarkBackground {
+			stringColor = StringColorForLight
+		}
+		printer = &SingleColoredPrinter{Color: stringColor}
 	}
 
 	printer.Print(r, w)


### PR DESCRIPTION
# Description

fix hard coded color for help messages

## Type of change

Please delete options that are not relevant.

- [X] fix hard coded color for help messages

## Related issue (if exists)
fixes #36 
