### PR TITLE
Fix tablescan freezing

### DIFF
--- a/internal/ctxscanner/ctxscanner.go
+++ b/internal/ctxscanner/ctxscanner.go
@@ -1,0 +1,84 @@
+// Package ctxscanner contains implementation of a scanner that takes in a
+// [context.Context], and allows it to be paused.
+package ctxscanner
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// Scanner is a wrapper around [bufio.Scanner] that takes in a context.
+type Scanner struct {
+	buf     *bufio.Scanner
+	ch      chan string
+	started bool
+	lastMsg string
+	lastErr error
+}
+
+func New(r io.Reader) *Scanner {
+	return &Scanner{
+		buf: bufio.NewScanner(r),
+		ch:  make(chan string, 100),
+	}
+}
+
+func (s *Scanner) scanGoroutine() {
+	defer func() {
+		close(s.ch)
+		if err := recover(); err != nil {
+			switch err := err.(type) {
+			case error:
+				s.lastErr = err
+			default:
+				s.lastErr = errors.New(fmt.Sprint(err))
+			}
+		}
+	}()
+	for s.buf.Scan() {
+		s.ch <- s.buf.Text()
+	}
+	if err := s.buf.Err(); err != nil {
+		s.lastErr = err
+	}
+}
+
+func (s *Scanner) Scan(ctx context.Context) (bool, error) {
+	if s.lastErr != nil {
+		return false, s.lastErr
+	}
+	if err := ctx.Err(); err != nil {
+		// Don't start the scanner if the context is already cancelled
+		return false, err
+	}
+	if !s.started {
+		s.started = true
+		go s.scanGoroutine()
+	}
+	select {
+	case text, ok := <-s.ch:
+		// ok=false when channel is closed
+		if !ok {
+			return false, s.lastErr
+		}
+		s.lastMsg = text
+		return true, nil
+	case <-ctx.Done():
+		return false, ctx.Err()
+	}
+}
+
+func (s *Scanner) Text() string {
+	return s.lastMsg
+}
+
+func (s *Scanner) Bytes() []byte {
+	return []byte(s.lastMsg)
+}
+
+func (s *Scanner) Err() error {
+	return s.lastErr
+}

--- a/printer/kubectl_apply_test.go
+++ b/printer/kubectl_apply_test.go
@@ -12,7 +12,6 @@ func Test_ApplyPrinter_Print(t *testing.T) {
 	tests := []struct {
 		name           string
 		darkBackground bool
-		tablePrinter   *TablePrinter
 		input          string
 		expected       string
 	}{

--- a/printer/kubectl_output_colored_printer.go
+++ b/printer/kubectl_output_colored_printer.go
@@ -200,8 +200,7 @@ func (kp *KubectlOutputColoredPrinter) Print(r io.Reader, w io.Writer) {
 			DarkBackground: kp.DarkBackground,
 			TablePrinter: NewTablePrinter(false, kp.DarkBackground, func(_ int, column string) (color.Color, bool) {
 				return ColorStatus(column)
-			},
-			),
+			}),
 		}
 	case kubectl.Explain:
 		printer = &ExplainPrinter{

--- a/printer/table.go
+++ b/printer/table.go
@@ -10,11 +10,6 @@ import (
 	"github.com/kubecolor/kubecolor/scanner/tablescan"
 )
 
-type tableColumnColor struct {
-	IndexInLine int
-	Color       color.Color
-}
-
 type TablePrinter struct {
 	WithHeader     bool
 	DarkBackground bool


### PR DESCRIPTION
# Description

PR #29 introduced a bug that causes `kubectl get pods --watch` to stop working.

The issue is that the new table scanner tries to buffer the entire table to be able to handle gaps in the table when figuring out where columns are. When using `--watch`, the underlying `bufio.Scanner` just freezes, as the output has not reached an EOF. As far as I can find, there's no way to detect if the `io.Reader` is waiting for data or has data available to be read. Would be nice with a `TryScan`/`TryRead`, but alas.

Instead I went for a timeout approach, where it times out after 50ms (perceived as near-instant), by using `context.WithTimeout`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you changed

- Added package `internal/ctxscanner`, a wrapper around `bufio.Scanner` that allows a `context.Context` in the scan method
- Changed `scanner/tablescan` package to use this new `ctxscanner`

## Why you think we should change it

Made the new `ctxscanner` internal because I don't really want others to depend on it.

Just removing the buffering from commands like `kubectl get` could be a solution, but then some outputs from `kubectl get --no-headers` could stop working when it tries to figure out where columns are.

## Related issue (if exists)

Closes #38
