### PR TITLE
README: Remove width & height attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ KubeColor is a `kubectl` replacement used to add colors to your kubectl output.
 <picture>
   <source srcset="./docs/kubectl-combined.png" media="(min-width: 1600px)" />
   <source srcset="./docs/kubectl-combined-medium.png" media="(min-width: 800px)" />
-  <img alt="Preview screenshots" src="./docs/kubectl-combined-small.png" width="787" height="916" />
+  <img alt="Preview screenshots" src="./docs/kubectl-combined-small.png" />
 </picture>
 
 * You can also change color theme for light-backgrounded environment


### PR DESCRIPTION
# Description

PR #40 added `<picture>` element to the README file.

But the `<img width="" height="">` attributes cause some unwanted resizing. It doesn't keep the aspect ratio when getting downsized.

| Before | After this PR |
| --- | ---
| ![image](https://github.com/kubecolor/kubecolor/assets/2477952/de9415fb-1ae1-4c06-9153-79aaa50b7fef) | ![image](https://github.com/kubecolor/kubecolor/assets/2477952/ce7c8a87-2c16-4beb-9ea8-c5b005160f9b)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you changed

- Updated README

## Why you think we should change it

Looks weird.

No need to create a new release for this. It's just docs

## Related issue (if exists)
