### PR TITLE
Added Scoop and Nix repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,17 +43,29 @@ Additionally, if `kubectl` resulted an error, kubecolor just shows the error mes
 
 ## Installation
 
-### Download binary via GitHub release
-
-Go to [Release page](https://github.com/kubecolor/kubecolor/releases) then download the binary which fits your environment.
-
-### Mac and Linux users via Homebrew
+### Homebrew
 
 ```sh
 brew install kubecolor/tap/kubecolor
 ```
 
-### Manually via Go command
+### Scoop
+
+```sh
+scoop install kubecolor
+```
+
+### Nix
+
+```sh
+nix-shell -p kubecolor
+```
+
+### Download binary via GitHub release
+
+Go to [Release page](https://github.com/kubecolor/kubecolor/releases) then download the binary which fits your environment.
+
+### Compile from source
 
 Requires Go 1.21 (or later)
 


### PR DESCRIPTION
# Description

More repositories that the user might be interested in.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## What you changed

- Added Scoop and Nixpkgs install docs to README
- Simplified headers for install docs

## Why you think we should change it

The PR to add kubecolor to the Main Scoop bucket was just merged: <https://github.com/ScoopInstaller/Main/pull/5425>

Also, in Nixpkgs it has started to get updated as well: <https://github.com/NixOS/nixpkgs/pull/279307> (only to 0.2.0 so far, but the automatic update actions they have plus ivankovnatsky being quite active should result in 0.2.1 being updated soon too)

## Related issue (if exists)

Closes #27
