### PR TITLE
Fix missing trailing table in kubectl describe

### DIFF
--- a/printer/kubectl_describe.go
+++ b/printer/kubectl_describe.go
@@ -58,6 +58,11 @@ func (dp *DescribePrinter) Print(r io.Reader, w io.Writer) {
 		}
 		fmt.Fprintf(w, "%s\n", line.Trailing)
 	}
+
+	if dp.tableBytes != nil {
+		dp.TablePrinter.Print(dp.tableBytes, w)
+		dp.tableBytes = nil
+	}
 }
 
 func (dp *DescribePrinter) valueColor(path describe.Path, value string) color.Color {

--- a/printer/kubectl_describe_test.go
+++ b/printer/kubectl_describe_test.go
@@ -136,6 +136,34 @@ func Test_DescribePrinter_Print(t *testing.T) {
 				[33mEvents[0m:              [33m<none>[0m
 			`),
 		},
+		{
+			name:           "table format in kubectl describe at the end",
+			darkBackground: true,
+			tablePrinter:   NewTablePrinter(false, true, nil),
+			input: testutil.NewHereDoc(`
+				Name:         cert-manager:leaderelection
+				Labels:       app=cert-manager
+											app.kubernetes.io/version=v1.12.3
+				Annotations:  meta.helm.sh/release-name: cert-manager
+											meta.helm.sh/release-namespace: nais-system
+				PolicyRule:
+					Resources                   Non-Resource URLs  Resource Names             Verbs
+					---------                   -----------------  --------------             -----
+					leases.coordination.k8s.io  []                 []                         [create]
+					leases.coordination.k8s.io  []                 [cert-manager-controller]  [get update patch]`),
+			expected: testutil.NewHereDoc(`
+				[33mName[0m:         [37mcert-manager:leaderelection[0m
+				[33mLabels[0m:       [37mapp=cert-manager[0m
+											[37mapp.kubernetes.io/version=v1.12.3[0m
+				[33mAnnotations[0m:  [37mmeta.helm.sh/release-name: cert-manager[0m
+											[37mmeta.helm.sh/release-namespace: nais-system[0m
+				[33mPolicyRule[0m:
+					[37mResources[0m                   [36mNon-Resource URLs[0m  [37mResource Names[0m             [36mVerbs[0m
+					[37m---------[0m                   [36m-----------------[0m  [37m--------------[0m             [36m-----[0m
+					[37mleases.coordination.k8s.io[0m  [36m[][0m                 [37m[][0m                         [36m[create][0m
+					[37mleases.coordination.k8s.io[0m  [36m[][0m                 [37m[cert-manager-controller][0m  [36m[get update patch][0m
+			`),
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
# Description

Regression from the new describe scanner. Forgot to print the table at the end, if there was one buffered up.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you changed

- Fixed issue in `printer.DescribePrinter` where it forgot to print a trailing table


## Why you think we should change it

Invalid output on commands such as:

```bash
kubectl describe pod my-pod
kubectl roles cert-manager:leaderelection
```

## Related issue (if exists)

Closes #48, closes #49
