### PR TITLE
Color status for `OOMKilled` and `<nil>`

### DIFF
--- a/printer/format.go
+++ b/printer/format.go
@@ -29,7 +29,7 @@ func getColorByKeyIndent(indent int, basicIndentWidth int, dark bool) color.Colo
 // This is intended to be used to colorize any structured data e.g. Json, Yaml.
 func getColorByValueType(val string, dark bool) color.Color {
 	switch val {
-	case "null", "<none>", "<unknown>", "<unset>":
+	case "null", "<none>", "<unknown>", "<unset>", "<nil>":
 		if dark {
 			return NullColorForDark
 		}

--- a/printer/kubectl_describe.go
+++ b/printer/kubectl_describe.go
@@ -51,7 +51,6 @@ func (dp *DescribePrinter) Print(r io.Reader, w io.Writer) {
 		fmt.Fprintf(w, "%s", line.Spacing)
 		if len(line.Value) > 0 {
 			val := string(line.Value)
-
 			valColor := dp.valueColor(scanner.Path(), val)
 			fmt.Fprint(w, color.Apply(val, valColor))
 
@@ -66,6 +65,7 @@ func (dp *DescribePrinter) Print(r io.Reader, w io.Writer) {
 }
 
 func (dp *DescribePrinter) valueColor(path describe.Path, value string) color.Color {
+	value = strings.TrimSpace(value)
 	if describeUseStatusColoring(path) {
 		if col, ok := ColorStatus(value); ok {
 			return col

--- a/printer/kubectl_describe_test.go
+++ b/printer/kubectl_describe_test.go
@@ -28,7 +28,16 @@ func Test_DescribePrinter_Print(t *testing.T) {
 				Ready:        true
 				Start Time:   Sat, 10 Oct 2020 14:07:17 +0900
 				Labels:       app=nginx
-				Annotations:  <none>`),
+				Annotations:  <none>
+				Conditions:
+				  Type              Status
+				  Initialized       True
+				  Ready             False
+				  ContainersReady   True
+				  PodScheduled      True
+				Volumes:
+				  kube-api-access-7fdrt:
+				    ConfigMapOptional:       <nil>`),
 			expected: testutil.NewHereDoc(`
 				[33mName[0m:         [37mnginx-lpv5x[0m
 				[33mNamespace[0m:    [37mdefault[0m
@@ -38,6 +47,15 @@ func Test_DescribePrinter_Print(t *testing.T) {
 				[33mStart Time[0m:   [37mSat, 10 Oct 2020 14:07:17 +0900[0m
 				[33mLabels[0m:       [37mapp=nginx[0m
 				[33mAnnotations[0m:  [33m<none>[0m
+				[33mConditions[0m:
+				  [37mType[0m              [37mStatus[0m
+				  [37mInitialized[0m       [32mTrue[0m
+				  [37mReady[0m             [31mFalse[0m
+				  [37mContainersReady[0m   [32mTrue[0m
+				  [37mPodScheduled[0m      [32mTrue[0m
+				[33mVolumes[0m:
+				  [37mkube-api-access-7fdrt[0m:
+				    [33mConfigMapOptional[0m:       [33m<nil>[0m
 			`),
 		},
 		{

--- a/printer/kubectl_output_colored_printer.go
+++ b/printer/kubectl_output_colored_printer.go
@@ -77,8 +77,6 @@ func ColorStatus(status string) (color.Color, bool) {
 		"FailedScheduling",
 		"Error",
 		"ErrImagePull",
-
-		// out of memory killed
 		"OOMKilled",
 		// PVC status
 		"Lost":

--- a/printer/kubectl_output_colored_printer.go
+++ b/printer/kubectl_output_colored_printer.go
@@ -78,6 +78,8 @@ func ColorStatus(status string) (color.Color, bool) {
 		"Error",
 		"ErrImagePull",
 
+		// out of memory killed
+		"OOMKilled",
 		// PVC status
 		"Lost":
 		return color.Red, true


### PR DESCRIPTION
# Description
Fix `kubecolor get pod` not show `OOMKilled` with color
fix `kubecolor describe pod` not show condition with color
<!--  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What you changed

## Why you think we should change it


## Related issue (if exists)
