### PR TITLE
Added note on AUR package to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,15 @@ Additionally, if `kubectl` resulted an error, kubecolor just shows the error mes
 
 ### Homebrew
 
+![GitHub Release](https://img.shields.io/github/v/release/kubecolor/kubecolor?display_name=tag&label=Homebrew&color=4cc61f)
+
 ```sh
 brew install kubecolor/tap/kubecolor
 ```
 
 ### Scoop
+
+![Scoop Version](https://img.shields.io/scoop/v/kubecolor?label=Scoop%2FMain&color=4cc61f)
 
 ```sh
 scoop install kubecolor
@@ -57,8 +61,18 @@ scoop install kubecolor
 
 ### Nix
 
+[![nixpkgs unstable package](https://repology.org/badge/version-for-repo/nix_unstable/kubecolor.svg)](https://repology.org/project/kubecolor/versions)
+
 ```sh
 nix-shell -p kubecolor
+```
+
+### AUR (Arch User Repositories)
+
+[![AUR package](https://repology.org/badge/version-for-repo/aur/kubecolor.svg)](https://repology.org/project/kubecolor/versions)
+
+```sh
+yay -Syu kubecolor
 ```
 
 ### Download binary via GitHub release


### PR DESCRIPTION
# Description

The AUR package was updated just hours ago: <https://aur.archlinux.org/cgit/aur.git/log/?h=kubecolor>. Let's include it in the README.

Also lets include some badges from Repology, where possible (<https://repology.org/project/kubecolor/versions>). The badges from them turn red when the package is outdated. However Repology does not include some repos (like our Homebrew tap or the Scoop main bucket), so I resorted to using shields.io for those.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## What you changed

- Updated README

## Why you think we should change it

More ways for users to install kubecolor

## Related issue (if exists)
