### PR TITLE
Update to Go 1.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.6 as build
+FROM docker.io/library/golang:1.22.0 as build
 
 WORKDIR /go/src/kubecolor
 COPY go.mod go.sum .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubecolor/kubecolor
 
-go 1.21.6
+go 1.22.0
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0


### PR DESCRIPTION
# Description

New version of Go just dropped yestarday :tada:

## What you changed

- Updated to Go 1.22

## Why you think we should change it

Stay up-to-date.

As kubecolor is an application and not a library, then we have the liberty to stay up-to-date. Thanks to Go's auto-updating forward-compatability feature introduced in Go 1.21, the minimum Go version required is still 1.21.

> This PR is marked as draft because the Docker image for golang:1.22 on amd64 [is not yet available](https://hub.docker.com/r/amd64/golang/tags?page=1&name=1.22.0).

## Related issue (if exists)
