### PR TITLE
Fix output from 'apply --dry-run=server'

### DIFF
--- a/printer/kubectl_apply_test.go
+++ b/printer/kubectl_apply_test.go
@@ -43,12 +43,21 @@ func Test_ApplyPrinter_Print(t *testing.T) {
 			`),
 		},
 		{
-			name:           "dry run",
+			name:           "client dry run",
 			darkBackground: true,
 			input: testutil.NewHereDoc(`
 				deployment.apps/foo unchanged (dry run)`),
 			expected: testutil.NewHereDoc(`
 				deployment.apps/foo [35munchanged[0m [36m(dry run)[0m
+			`),
+		},
+		{
+			name:           "server dry run",
+			darkBackground: true,
+			input: testutil.NewHereDoc(`
+				deployment.apps/foo unchanged (server dry run)`),
+			expected: testutil.NewHereDoc(`
+				deployment.apps/foo [35munchanged[0m [36m(server dry run)[0m
 			`),
 		},
 		{


### PR DESCRIPTION
# Description

The output from `--dry-run=client` and `--dry-run=server` differs.

Before:
![image](https://github.com/kubecolor/kubecolor/assets/2477952/6636e8a9-45e2-4e29-9095-e34ba1256ed2)


After:
![image](https://github.com/kubecolor/kubecolor/assets/2477952/b7ce1533-c4b8-4c0d-9d6b-e41d5ac969d4)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What you changed

- Rewrote the logic behind `printer/kubectl_apply.go`
- Added case for `(server dry run)`

## Why you think we should change it

Bugfix

## Related issue (if exists)

Closes #57
