### PR TITLE
Fix some coloring issues from the coloring PR

### DIFF
--- a/config/color.go
+++ b/config/color.go
@@ -78,7 +78,7 @@ func ParseColor(s string) (Color, error) {
 		}
 
 		if field == "none" {
-			return Color{}, nil
+			continue
 		}
 
 		c, err := parseColorField(field)

--- a/config/theme.go
+++ b/config/theme.go
@@ -14,7 +14,7 @@ func NewBaseTheme(preset Preset) *Theme {
 	switch preset {
 	case PresetDark:
 		return &Theme{
-			Default: MustParseColor("yellow"),
+			Default: MustParseColor("green"),
 			Base: ThemeBase{
 				Key:       MustParseColorSlice("yellow / white"),
 				Info:      MustParseColor("white"),
@@ -35,7 +35,7 @@ func NewBaseTheme(preset Preset) *Theme {
 
 	case PresetLight:
 		return &Theme{
-			Default: MustParseColor("yellow"),
+			Default: MustParseColor("green"),
 			Base: ThemeBase{
 				Key:       MustParseColorSlice("yellow / black"),
 				Info:      MustParseColor("black"),

--- a/printer/table.go
+++ b/printer/table.go
@@ -125,7 +125,10 @@ func (tp *TablePrinter) getColumnBaseColor(index int, colorsPreset []config.Colo
 		return config.Color{}
 	}
 	if tp.hasLeadingNamespaceColumn {
-		index++
+		index--
+		if index < 0 {
+			index += len(colorsPreset)
+		}
 	}
 	return colorsPreset[index%len(colorsPreset)]
 }


### PR DESCRIPTION
# Description

<!--  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes some issues that were partially introduced in #59

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you changed

- Fixed color cycle adjustment flipping the wrong order when first column is `NAMESPACE`
- Fixed parsing of when color string contains `none` field
- Fixed wrong default color for commands

## Why you think we should change it

Fixes some regressions.

## Related issue (if exists)

