### PR TITLE
Added pre-0.0.21 color preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,8 @@ We have some presets that come shipped with kubecolor:
 | ------             | -----------
 | `dark` *(default)* | For when your terminal's background is dark.
 | `light`            | For when your terminal's background is light/bright.
+| `pre-0.0.21-dark`  | Original dark color scheme used before v0.0.21, as well as in the predecessor's ([hidetatz/kubecolor](https://github.com/hidetatz/kubecolor)) version.
+| `pre-0.0.21-light` | Original light color scheme used before v0.0.21, as well as in the predecessor's ([hidetatz/kubecolor](https://github.com/hidetatz/kubecolor)) version.
 
 Selecting preset can be done via the `KUBECOLOR_PRESET` environment variable,
 like so:

--- a/config/preset.go
+++ b/config/preset.go
@@ -12,6 +12,9 @@ const (
 	PresetUnknown Preset = iota
 	PresetDark
 	PresetLight
+
+	PresetPre0021Dark
+	PresetPre0021Light
 )
 
 var (
@@ -29,6 +32,10 @@ func (p Preset) String() string {
 		return "dark"
 	case PresetLight:
 		return "light"
+	case PresetPre0021Dark:
+		return "pre-0.0.21-dark"
+	case PresetPre0021Light:
+		return "pre-0.0.21-light"
 	default:
 		return fmt.Sprintf("%[1]T(%[1]d)", p)
 	}
@@ -41,6 +48,10 @@ func ParsePreset(s string) (Preset, error) {
 		return PresetDark, nil
 	case "light":
 		return PresetLight, nil
+	case "pre-0.0.21-dark":
+		return PresetPre0021Dark, nil
+	case "pre-0.0.21-light":
+		return PresetPre0021Light, nil
 	default:
 		return Preset(0), fmt.Errorf("invalid theme preset: %q", s)
 	}

--- a/config/theme.go
+++ b/config/theme.go
@@ -54,6 +54,60 @@ func NewBaseTheme(preset Preset) *Theme {
 			},
 		}
 
+	case PresetPre0021Dark:
+		return &Theme{
+			Default: MustParseColor("green"),
+			Base: ThemeBase{
+				Key:       MustParseColorSlice("yellow / white"),
+				Info:      MustParseColor("white"),
+				Primary:   MustParseColor("magenta"),
+				Secondary: MustParseColor("cyan"),
+				Success:   MustParseColor("green"),
+				Warning:   MustParseColor("yellow"),
+				Danger:    MustParseColor("red"),
+				Muted:     MustParseColor("yellow"),
+			},
+			Data: ThemeData{
+				String: MustParseColor("cyan"),
+			},
+			Table: ThemeTable{
+				Columns: MustParseColorSlice("cyan / green / magenta / white / yellow"),
+			},
+			Status: ThemeStatus{
+				Success: MustParseColor("none"),
+			},
+			Options: ThemeOptions{
+				Flag: MustParseColor("yellow"),
+			},
+		}
+
+	case PresetPre0021Light:
+		return &Theme{
+			Default: MustParseColor("green"),
+			Base: ThemeBase{
+				Key:       MustParseColorSlice("yellow / black"),
+				Info:      MustParseColor("white"),
+				Primary:   MustParseColor("magenta"),
+				Secondary: MustParseColor("cyan"),
+				Success:   MustParseColor("green"),
+				Warning:   MustParseColor("yellow"),
+				Danger:    MustParseColor("red"),
+				Muted:     MustParseColor("yellow"),
+			},
+			Data: ThemeData{
+				String: MustParseColor("blue"),
+			},
+			Table: ThemeTable{
+				Columns: MustParseColorSlice("cyan / green / magenta / black / yellow / blue"),
+			},
+			Status: ThemeStatus{
+				Success: MustParseColor("none"),
+			},
+			Options: ThemeOptions{
+				Flag: MustParseColor("yellow"),
+			},
+		}
+
 	default:
 		panic(fmt.Sprintf("invalid theme preset: %s", preset))
 	}


### PR DESCRIPTION
# Description

<!--  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

One of the first issues on this repo was that the color scheme changed (#4). 

## Preview

![image](https://github.com/kubecolor/kubecolor/assets/2477952/d48fa898-37c7-41b2-aa4a-30bf349abee5)

The coloring is not identical in some areas such as `kubectl describe`, but it's close enough. Can't get 100% old scheme as a lot of parsing is done differently now.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you changed

- Added color schemes from the pre-0.0.21/hidetatz version

## Why you think we should change it

For people coming from hidetatz's kubecolor then this is a big change. This PR adds back that color scheme, in case they really liked it.

## Related issue (if exists)

Relates to #4
