### PR TITLE
Added docs on `oc` usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,12 @@ you can use kubecolor as a complete alternative of kubectl. It means you can wri
 
 ```sh
 alias kubectl="kubecolor"
+
+# Also works for OpenShift CLI
+export KUBECTL_COMMAND="oc"
+alias oc="kubecolor"
 ```
+
 If you use your .bash_profile on more than one computer (e.g. synced via git) that might not all have `kubecolor`
 installed, you can avoid breaking `kubectl` like so:
 


### PR DESCRIPTION
# Description

<!--  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Kubecolor works fine with `oc` as well as `kubectl`, as we noticed in #63

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## What you changed

- Added note to README about `alias oc=kubecolor`

## Why you think we should change it

Show users up front that we support `oc` as well

## Related issue (if exists)

Closes #64
