### PR TITLE
Added docs on running via Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,31 @@ Additionally, if `kubectl` resulted an error, kubecolor just shows the error mes
 
 ## Installation
 
+### Docker
+
+Running it via Docker can be nice for just trying out kubecolor:
+
+```bash
+docker run --rm -it -v $HOME/.kube:/home/nonroot/.kube:ro ghcr.io/kubecolor/kubecolor get pods
+```
+
+<details>
+<summary>If you're getting the following error <code>permission denied</code> (click to expand)</summary>
+
+> In case you are getting the following error (common in environments like WSL):
+>
+> ```log
+> error: error loading config file "/home/nonroot/.kube/config": open /home/nonroot/.kube/config: permission denied
+> ```
+>
+> then try changing the permission of your `~/.kube/config` file:
+>
+> ```bash
+> chmod 644 ~/.kube/config
+> ```
+
+</details>
+
 ### Homebrew
 
 ![GitHub Release](https://img.shields.io/github/v/release/kubecolor/kubecolor?display_name=tag&label=Homebrew&color=4cc61f)


### PR DESCRIPTION
# Description

<!--  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Docs on running via Docker, as well as mounting the `~/.kube/config` (and upcoming `~/.kube/color.yaml`) correctly

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## What you changed

- Updated README

## Why you think we should change it

Our Docker image has existed for a while, but we haven't really made use of it.

GitHub says that the `v0.2.2` Docker image has been downloaded like 48 times, but my guess is that's only by automated bots trying to scan for vulnerabilities or something. I don't expect we have that much traffic of people using the Docker image when we don't even have docs on it.

## Related issue (if exists)
