### PR TITLE
Skip pushing Docker image for each merge

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -4,38 +4,11 @@ on:
     branches:
       - 'main'
     tags:
-      - '*'
+      - 'v*'
 jobs:
-  push_to_registry_on_merge:
-    name: Push docker image on merge to main
-    runs-on: ubuntu-latest
-    if: (!contains(github.event.head_commit.message, 'skip ci') && !startsWith(github.ref, 'refs/tags/'))
-    steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Check out the repo
-        uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository }}:${{ github.sha }}
-          build-args:
-            VERSION=${{ github.sha }}
   push_to_registry_on_tag:
     name: Push docker image to GitHub Container Registry on tag
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,3 +36,24 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # required
           verbose: true # optional (default = false)
+
+  build-docker:
+    name: Build docker image
+    runs-on: ubuntu-latest
+    if: (!contains(github.event.head_commit.message, 'skip ci'))
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build, but don't push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.sha }}
+          build-args:
+            VERSION=${{ github.sha }}


### PR DESCRIPTION
# Description

<!--  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Removes the pushing of Docker images on each merge.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you changed

- Removed pushing to GitHub Container Registry on each merge
- Added building (but not pushing) Docker image on pull requests

## Why you think we should change it

The Docker image is not our main delivery source, and I doubt many are running kubecolor in things like docker-compose or Kubernetes.

We can keep the tagged versions, but I propose we skip the (quite noisy) per-merge pushes. Just see for yourself: <https://github.com/kubecolor/kubecolor/pkgs/container/kubecolor/versions?filters%5Bversion_type%5D=tagged>

This also adds the building step, so we can ensure that the Docker image would be successfully built after a PR.

## Related issue (if exists)
