### PR TITLE
Colorize duration & quantity

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -191,9 +191,13 @@
           "$ref": "#/$defs/color",
           "description": "used when the value is null, nil, or none"
         },
+        "quantity": {
+          "$ref": "#/$defs/color",
+          "description": "used when the value is a quantity, e.g \"100m\" or \"5Gi\""
+        },
         "duration": {
           "$ref": "#/$defs/color",
-          "description": "used when the value is a duration, e.g \"12m\""
+          "description": "used when the value is a duration, e.g \"12m\" or \"1d12h\""
         },
         "durationFresh": {
           "$ref": "#/$defs/color",

--- a/config/theme.go
+++ b/config/theme.go
@@ -294,7 +294,8 @@ type ThemeData struct {
 	Number Color      `defaultFrom:"theme.base.primary"` // used when the value is a number
 	Null   Color      `defaultFrom:"theme.base.muted"`   // used when the value is null, nil, or none
 
-	Duration      Color ``                                 // used when the value is a duration, e.g "12m"
+	Quantity      Color `defaultFrom:"theme.data.number"`  // used when the value is a quantity, e.g "100m" or "5Gi"
+	Duration      Color `defaultFrom:"theme.data.number"`  // used when the value is a duration, e.g "12m" or "1d12h"
 	DurationFresh Color `defaultFrom:"theme.base.success"` // color used when the time value is under a certain delay
 
 	Ratio ThemeDataRatio

--- a/config/theme.go
+++ b/config/theme.go
@@ -295,7 +295,7 @@ type ThemeData struct {
 	Null   Color      `defaultFrom:"theme.base.muted"`   // used when the value is null, nil, or none
 
 	Quantity      Color `defaultFrom:"theme.data.number"`  // used when the value is a quantity, e.g "100m" or "5Gi"
-	Duration      Color `defaultFrom:"theme.data.number"`  // used when the value is a duration, e.g "12m" or "1d12h"
+	Duration      Color ``                                 // used when the value is a duration, e.g "12m" or "1d12h"
 	DurationFresh Color `defaultFrom:"theme.base.success"` // color used when the time value is under a certain delay
 
 	Ratio ThemeDataRatio

--- a/printer/format.go
+++ b/printer/format.go
@@ -30,7 +30,7 @@ var (
 // This is intended to be used to colorize any structured data e.g. Json, Yaml.
 func getColorByValueType(val string, theme *config.Theme) config.Color {
 	switch val {
-	case "null", "<none>", "<unknown>", "<unset>", "<nil>":
+	case "null", "<none>", "<unknown>", "<unset>", "<nil>", "<invalid>":
 		return theme.Data.Null
 	case "true", "True":
 		return theme.Data.True

--- a/printer/format.go
+++ b/printer/format.go
@@ -1,6 +1,7 @@
 package printer
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/kubecolor/kubecolor/config"
@@ -20,6 +21,10 @@ func getColorByKeyIndent(indent int, basicIndentWidth int, colors config.ColorSl
 	}
 	return colors[indent/basicIndentWidth%len(colors)]
 }
+
+var (
+	isQuantityRegex = regexp.MustCompile(`^[\+\-]?(?:\d+|\.\d+|\d+\.|\d+\.\d+)?(?:m|[kMGTPE]i?)$`)
+)
 
 // getColorByValueType returns a color by value.
 // This is intended to be used to colorize any structured data e.g. Json, Yaml.
@@ -43,6 +48,16 @@ func getColorByValueType(val string, theme *config.Theme) config.Color {
 		if stringutil.IsOnlyDigits(left) && stringutil.IsOnlyDigits(right) {
 			return theme.Data.Number
 		}
+	}
+
+	// Quantity: 100m, 5Gi
+	if isQuantityRegex.MatchString(val) {
+		return theme.Data.Quantity
+	}
+
+	// Duration: 15m10s
+	if _, ok := stringutil.ParseHumanDuration(val); ok {
+		return theme.Data.Duration
 	}
 
 	return theme.Data.String


### PR DESCRIPTION
# Description

<!--  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Durations (3d12h) and quantities (5Gi) have been lacking colors.

## Before

![image](https://github.com/kubecolor/kubecolor/assets/2477952/43ccc2ed-efe1-461b-bf3e-9318a57ad738)


## After

![image](https://github.com/kubecolor/kubecolor/assets/2477952/623b4f3e-7dfa-4e08-bacc-45e10d2cad01)


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you changed

- Added color matching on duration and quantity
- Also treat invalid as null

## Why you think we should change it

Clearer to see values like resource requests and limits in outputs like `kubectl describe`

## Related issue (if exists)

Closes #72, closes #73
