### PR TITLE
Fix GLIBC_2.34 version error in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ RUN go mod download
 
 COPY . .
 ARG VERSION
-RUN go install -ldflags="-X main.Version=${VERSION}" .
+RUN CGO_ENABLED=0 go install -ldflags="-X main.Version=${VERSION}" .
 
-FROM gcr.io/distroless/base:nonroot
+FROM gcr.io/distroless/static-debian11:nonroot
 COPY --from=build /go/bin/kubecolor /usr/local/bin/
 COPY --from=bitnami/kubectl /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
 ENTRYPOINT ["kubecolor"]


### PR DESCRIPTION
# Description

<!--  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The docker image was failing:

```console
$ podman run --rm -it -v $HOME/.kube:/home/nonroot/.kube:ro ghcr.io/kubecolor/kubecolor get pods
kubecolor: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by kubecolor)
kubecolor: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by kubecolor)
```

According to the distroless example, they seem to suggest disabling CGO: <https://github.com/GoogleContainerTools/distroless/blob/main/examples/go/Dockerfile>

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you changed

- Disabled CGO in Docker build
- Switched to static-debian distroless base image

## Why you think we should change it

Fixes not being able to run the Docker image.

## Related issue (if exists)
