### PR TITLE
Update Go to 1.22.2

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Create GitHub issue
         uses: JasonEtco/create-an-issue@v2
-        if: ${{ failure() && steps.govulncheck.conclusion == 'failure' && github.event_name == 'schedule' }}
+        if: ${{ !cancelled() && steps.govulncheck.conclusion == 'failure' && github.event_name == 'schedule' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOVULNCHECK_OUTPUT: ${{ steps.govulncheck.outputs.govulncheck }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.22.1 as build
+FROM docker.io/library/golang:1.22.2 as build
 
 WORKDIR /go/src/kubecolor
 COPY go.mod go.sum .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubecolor/kubecolor
 
-go 1.22.1
+go 1.22.2
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0


### PR DESCRIPTION
# Description

<!--  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

govulncheck just reported that we need to upgrade to Go 1.22.2 due to vulnerability:

```console
$ govulncheck ./...
Scanning your code and 226 packages across 29 dependent modules for known vulnerabilities...

=== Symbol Results ===

Vulnerability #1: GO-2024-2687
    HTTP/2 CONTINUATION flood in net/http
  More info: https://pkg.go.dev/vuln/GO-2024-2687
  Standard library
    Found in: net/http@go1.22.1
    Fixed in: net/http@go1.22.2
    Example traces found:
      #1: testutil/heredoc.go:21:32: testutil.NewHereDocf calls strings.Replacer.Replace, which eventually calls http.CanonicalHeaderKey
      #2: config/config.go:57:26: config.LoadViper calls viper.Viper.ReadInConfig, which eventually calls http.bodyEOFSignal.Read
      #3: internal/cmd/configschema/main.go:122:14: configschema.main calls fmt.Fprintln, which eventually calls http.http2ErrCode.String
      #4: internal/cmd/configschema/main.go:122:14: configschema.main calls fmt.Fprintln, which eventually calls http.http2FrameType.String
      #5: internal/cmd/configschema/main.go:122:14: configschema.main calls fmt.Fprintln, which eventually calls http.http2Setting.String
      #6: internal/cmd/configschema/main.go:122:14: configschema.main calls fmt.Fprintln, which eventually calls http.http2SettingID.String
      #7: config/config.go:96:14: config.ApplyThemePreset calls fmt.Fprintf, which eventually calls http.http2chunkWriter.Write
      #8: config/config.go:95:14: config.ApplyThemePreset calls viper.Viper.GetBool, which eventually calls http.http2duplicatePseudoHeaderError.Error
      #9: config/config.go:95:14: config.ApplyThemePreset calls viper.Viper.GetBool, which eventually calls http.http2headerFieldNameError.Error
      #10: config/config.go:95:14: config.ApplyThemePreset calls viper.Viper.GetBool, which eventually calls http.http2headerFieldValueError.Error
      #11: config/config.go:95:14: config.ApplyThemePreset calls viper.Viper.GetBool, which eventually calls http.http2pseudoHeaderError.Error
      #12: internal/cmd/configschema/main.go:122:14: configschema.main calls fmt.Fprintln, which eventually calls http.http2writeData.String
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you changed

- Updated Go in go.mod & Dockerfile

## Why you think we should change it

Vulnerability bad

## Related issue (if exists)
