### PR TITLE
Added flag `--kubecolor-stdin` to allow piping in output

### DIFF
--- a/command/config.go
+++ b/command/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	ForceColor           bool
 	ShowKubecolorVersion bool
 	KubectlCmd           string
+	StdinOverride        string
 	ObjFreshThreshold    time.Duration
 	Theme                *config.Theme
 
@@ -79,6 +80,14 @@ func ResolveConfigViper(inputArgs []string, v *viper.Viper) (*Config, error) {
 				return nil, err
 			}
 			cfg.ShowKubecolorVersion = b
+		case "--kubecolor-stdin":
+			// Value means "read from file"
+			// Dash "-" means "read from stdin"
+			// Empty, as in just "--kubecolor-stdin", means "read from stdin"
+			if value == "" {
+				value = "-"
+			}
+			cfg.StdinOverride = value
 		case "--kubecolor-theme":
 			v.Set(config.PresetKey, value)
 		default:

--- a/internal/bytesutil/bytesutil_test.go
+++ b/internal/bytesutil/bytesutil_test.go
@@ -4,39 +4,39 @@ import "testing"
 
 func TestCountColumns(t *testing.T) {
 	tests := []struct {
-		name string
+		name  string
 		input string
-		want int
+		want  int
 	}{
 		{
-			name: "empty",
+			name:  "empty",
 			input: "",
-			want: 0,
+			want:  0,
 		},
 
 		{
-			name: "only space",
+			name:  "only space",
 			input: "       ",
-			want: 0,
+			want:  0,
 		},
 
 		{
-			name: "single",
+			name:  "single",
 			input: "foo",
-			want: 1,
+			want:  1,
 		},
 
 		{
-			name: "three/narrow spacing",
+			name:  "three/narrow spacing",
 			input: "foo  bar  moo",
-			want: 3,
+			want:  3,
 		},
 
 		{
 			// This is where an implementation using [strings.Count] would fail.
-			name: "three/excessive spacing",
+			name:  "three/excessive spacing",
 			input: "foo                bar             moo",
-			want: 3,
+			want:  3,
 		},
 	}
 


### PR DESCRIPTION

# Description

<!--  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds a new flag: `--kubecolor-stdin`

Can be used as:

```bash
kubectl get pods > kubectl-output.txt

# option 1:
cat kubectl-output.txt | kubecolor get pods --kubecolor-stdin

# option 2:
kubecolor get pods --kubecolor-stdin=./kubectl-output.txt
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you changed

- Added flag for setting stdin source

## Why you think we should change it

Makes it easier to debug kubecolor. It's a quite simple change, but can be quite useful when debugging

## Related issue (if exists)

Closes #94
