### PR TITLE
Kubecolor is now available on homebrew-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ docker run --rm -it -v $HOME/.kube:/home/nonroot/.kube:ro ghcr.io/kubecolor/kube
 
 ### Homebrew
 
-[![GitHub Release](https://img.shields.io/github/v/release/kubecolor/kubecolor?display_name=tag&label=Homebrew&color=4cc61f)](https://github.com/kubecolor/homebrew-tap)
+[![Homebrew version](https://repology.org/badge/version-for-repo/homebrew/kubecolor.svg)](https://repology.org/project/kubecolor/versions)
 
 ```sh
-brew install kubecolor/tap/kubecolor
+brew install kubecolor
 ```
 
 ### Scoop


### PR DESCRIPTION
# Description

<!--  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Homebrew PR was merged: https://github.com/Homebrew/homebrew-core/pull/166705

The package is also available on Homebrew Formulae: https://formulae.brew.sh/formula/kubecolor

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## What you changed

- Updated Homebrew docs in README

## Why you think we should change it

This does not remove the custom brew tap in `.goreleaser.yml`. Anyone still using that might want to keep getting updates.

## Related issue (if exists)

Closes #54
