### PR TITLE
Disable CGO in release binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,3 @@
-release:
 
 before:
   hooks:
@@ -9,6 +8,8 @@ builds:
 - id: kubecolor
   main: ./main.go
   binary: kubecolor
+  env:
+    - CGO_ENABLED=0
   ldflags:
     - -s -w
     - -X main.Version={{.Version}}


### PR DESCRIPTION
# Description

<!--  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Disables CGO in goreleaser, as CGO adds dependencies on host libraries like specific version of glibc.

I noticed this because I was using kubecolor in GH Actions at work, and all of the sudden they stopped working because v0.3.0 was released and we were targeting 'latest' :)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you changed

- Added `CGO_ENABLED=0` env var to goreleaser builds

## Why you think we should change it

Depending on specific glibc versions means only some people can run the binaries.

Disabling CGO does increase the binary size a bit, but it also makes it self-contained with no host dependencies.

## Related issue (if exists)

Closes #104
