### PR TITLE
Fixed kubecolor adding colors in completions

### DIFF
--- a/command/subcommand.go
+++ b/command/subcommand.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"os"
-	"strings"
 
 	"github.com/kubecolor/kubecolor/kubectl"
 	"github.com/mattn/go-isatty"
@@ -25,17 +24,13 @@ func ResolveSubcommand(args []string, config *Config) (bool, *kubectl.Subcommand
 	// if subcommand is not found (e.g. kubecolor --help or just "kubecolor"),
 	// it is treated as help because kubectl shows help for such input
 	if !subcommandFound {
-		// if there is an argument starting with __,
-		// the subcommand is probably an internal subcommand (like __completeNoDesc)
-		// and should probably not be colorized
-		for i := range args {
-			if strings.HasPrefix(args[i], "__") {
-				return false, subcommandInfo
-			}
-		}
-
 		subcommandInfo.Help = true
 		return true, subcommandInfo
+	}
+
+	colorsSupported := isColoringSupported(subcommandInfo.Subcommand)
+	if !colorsSupported {
+		return false, subcommandInfo
 	}
 
 	// when the command output tty is not standard output, shouldColorize depends on --force-colors flag.
@@ -47,26 +42,27 @@ func ResolveSubcommand(args []string, config *Config) (bool, *kubectl.Subcommand
 	}
 
 	// else, when the given subcommand is supported, then we colorize it
-	return subcommandFound && isColoringSupported(subcommandInfo.Subcommand), subcommandInfo
+	return subcommandFound, subcommandInfo
 }
 
 // when you add something here, it won't be colorized
 var unsupported = map[kubectl.Subcommand]struct{}{
-	kubectl.Attach:        {},
-	kubectl.Completion:    {},
-	kubectl.Create:        {},
-	kubectl.Ctx:           {},
-	kubectl.Debug:         {},
-	kubectl.Delete:        {},
-	kubectl.Edit:          {},
-	kubectl.Exec:          {},
-	kubectl.KubectlPlugin: {},
-	kubectl.Ns:            {},
-	kubectl.Plugin:        {},
-	kubectl.Proxy:         {},
-	kubectl.Replace:       {},
-	kubectl.Run:           {},
-	kubectl.Wait:          {},
+	kubectl.Attach:           {},
+	kubectl.Completion:       {},
+	kubectl.Create:           {},
+	kubectl.Ctx:              {},
+	kubectl.Debug:            {},
+	kubectl.Delete:           {},
+	kubectl.Edit:             {},
+	kubectl.Exec:             {},
+	kubectl.InternalComplete: {},
+	kubectl.KubectlPlugin:    {},
+	kubectl.Ns:               {},
+	kubectl.Plugin:           {},
+	kubectl.Proxy:            {},
+	kubectl.Replace:          {},
+	kubectl.Run:              {},
+	kubectl.Wait:             {},
 
 	// oc (OpenShift CLI) specific subcommands
 	kubectl.Rsh: {},


### PR DESCRIPTION
# Description

Was looking into #111, where the user had issues using `alias k='kubecolor --force-colors'`.

There were 2 things going wrong here:
- It parsed `kubecolor __complete get` as `command=get` instead of `command=__complete`
- Turns out that `--force-colors` had precedence over if command is marked as "colors unsupported"

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What you changed

- Fixed  `--force-colors` having higher precedence than `isColoringSupported()`
- Fixed parsing of `__complete` subcommands

## Why you think we should change it

Resolves edge cases where users use `alias k='kubecolor --force-colors'`

## Related issue (if exists)

Closes #111
