### PR TITLE
KUBECOLOR_LIGHT_BACKGROUND was working in reverse

### DIFF
--- a/command/config.go
+++ b/command/config.go
@@ -37,9 +37,9 @@ func ResolveConfigViper(inputArgs []string, v *viper.Viper) (*Config, error) {
 		return nil, err
 	} else if ok {
 		if lightThemeEnv {
-			v.Set(config.PresetKey, "dark")
-		} else {
 			v.Set(config.PresetKey, "light")
+		} else {
+			v.Set(config.PresetKey, "dark")
 		}
 	}
 

--- a/command/config_test.go
+++ b/command/config_test.go
@@ -74,7 +74,7 @@ func Test_ResolveConfig(t *testing.T) {
 				Plain:           false,
 				ForceColor:      false,
 				KubectlCmd:      "kubectl",
-				Theme:           testconfig.DarkTheme,
+				Theme:           testconfig.LightTheme,
 				ArgsPassthrough: []string{"get", "pods"},
 			},
 		},


### PR DESCRIPTION
# Description

The `KUBECOLOR_LIGHT_BACKGROUND` variable is working in reverse:

What we should have is:
<img width="804" alt="image" src="https://github.com/kubecolor/kubecolor/assets/1110398/1519fd95-7f7c-4236-a5eb-299d40dbbb6b">

What we have:

`KUBECOLOR_LIGHT_BACKGROUND=false` should be dark:
<img width="855" alt="image" src="https://github.com/kubecolor/kubecolor/assets/1110398/1154b640-1601-45cb-9322-22858db210b5">

`KUBECOLOR_LIGHT_BACKGROUND=false` should be light:
<img width="851" alt="image" src="https://github.com/kubecolor/kubecolor/assets/1110398/482d3861-8b99-4ae5-824a-57e0c11afcc1">

but we have the opposit :)



## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you changed
switched the default color theme when changing the `KUBECOLOR_LIGHT_BACKGROUND` variable

## Why you think we should change it
because it's a bug :)

## Related issue (if exists)
