### PR TITLE
feat: pipe through pager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ dist/
 .DS_Store
 kubecolor
 *.exe
+
+coverage.txt
+cover.html

--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ Example file (the values shows the default values):
 kubectl: kubectl # path to kubectl executable
 preset: dark # color theme preset
 objFreshThreshold: 0 # ages below this uses theme.data.durationfresh coloring
+pager: "" # command to run as pager
 
 # Color theme options
 theme:

--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ For example, when you want to pass kubecolor result to grep (`kubecolor get pods
 
 When you don't want to colorize output, you can specify `--plain`. Kubecolor understands this option and outputs the result without colorizing.
 
+* `--pager`
+
+Pipe the output of the `get` and `describe` subcommands to a pager. Kubecolor tries a pager defined by `$KUBEPAGER`, `$PAGER` and the command `pager`, in that order. When using less, use `PAGER="less -R"` to pass color escape sequences and use `PAGER="less -RF"` to exit the pager if the file can be displayed on the first screen.
+
 ### ENV Variables
 
 * `KUBECOLOR_OBJ_FRESH`

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ When you don't want to colorize output, you can specify `--plain`. Kubecolor und
 
 * `--pager`
 
-Pipe the output of the `get` and `describe` subcommands to a pager. Kubecolor tries a pager defined by `$KUBEPAGER`, `$PAGER` and the command `pager`, in that order. When using less, use `PAGER="less -R"` to pass color escape sequences and use `PAGER="less -RF"` to exit the pager if the file can be displayed on the first screen.
+Pipe the output of the `get` and `describe` subcommands to a pager. Kubecolor tries a pager defined by `$KUBECOLOR_PAGER`, then `$PAGER` and then tries less and more. When using less, use `less -R` to pass color escape sequences and use `less -RF` to exit the pager if the file can be displayed on the first screen.
 
 ### ENV Variables
 
@@ -535,7 +535,9 @@ Example file (the values shows the default values):
 kubectl: kubectl # path to kubectl executable
 preset: dark # color theme preset
 objFreshThreshold: 0 # ages below this uses theme.data.durationfresh coloring
-pager: "" # command to run as pager
+pager:
+  enabled: false # whether to use a pager
+  cmd: # command to run as pager
 
 # Color theme options
 theme:

--- a/README.md
+++ b/README.md
@@ -543,7 +543,7 @@ Example file (the values shows the default values):
 kubectl: kubectl # path to kubectl executable
 preset: dark # color theme preset
 objFreshThreshold: 0 # ages below this uses theme.data.durationfresh coloring
-paging: always # whether to pipe supported subcommands to a pager ("always" or "never")
+paging: auto # whether to pipe supported subcommands to a pager ("auto" or "never")
 pager: # the command to use as pager; default uses $PAGER, less, or more
 
 # Color theme options

--- a/README.md
+++ b/README.md
@@ -384,11 +384,11 @@ colors of your output.
 | `KUBECOLOR_THEME_STATUS_WARNING`     | color   | used in status keywords, e.g "Terminating"<br/>*(fallback to `KUBECOLOR_THEME_BASE_WARNING`)*                                                                                                                                                       | `yellow`
 | `KUBECOLOR_THEME_STATUS_ERROR`       | color   | used in status keywords, e.g "Failed", "Unhealthy"<br/>*(fallback to `KUBECOLOR_THEME_BASE_DANGER`)*                                                                                                                                                | `red`
 |                                      |         |                                                                                                                                                                                                                                                     |
-| `KUBECOLOR_THEME_TABLE_HEADER`       | color   | used on table headers<br/>*(fallback to `KUBECOLOR_THEME_BASE_INFO`)*                                                                                                                                                                               | `fg=white:#aaff00`
+| `KUBECOLOR_THEME_TABLE_HEADER`       | color   | used on table headers<br/>*(fallback to `KUBECOLOR_THEME_BASE_INFO`)*                                                                                                                                                                               | `bold`
 | `KUBECOLOR_THEME_TABLE_COLUMNS`      | color[] | used on table columns when no other coloring applies such as status or duration coloring. The multiple colors are cycled based on column ID, from left to right.<br/>*(fallback to `[KUBECOLOR_THEME_BASE_INFO / KUBECOLOR_THEME_BASE_SECONDARY]`)* | `white / cyan`
 |                                      |         |                                                                                                                                                                                                                                                     |
 | `KUBECOLOR_THEME_STDERR_DEFAULT`     | color   | default when no specific mapping is found for the output line<br/>*(fallback to `KUBECOLOR_THEME_BASE_INFO`)*                                                                                                                                       | `white`
-| `KUBECOLOR_THEME_STDERR_ERROR`       | color   | e.g when text contains "error"<br/>*(fallback to `KUBECOLOR_THEME_BASE_DANGER`)*                                                                                                                                                                    | `fg=hi-yellow:bg=red:bold`
+| `KUBECOLOR_THEME_STDERR_ERROR`       | color   | e.g when text contains "error"<br/>*(fallback to `KUBECOLOR_THEME_BASE_DANGER`)*                                                                                                                                                                    | `red`
 |                                      |         |                                                                                                                                                                                                                                                     |
 | `KUBECOLOR_THEME_DESCRIBE_KEY`       | color[] | used on keys. The multiple colors are cycled based on indentation.<br/>*(fallback to `KUBECOLOR_THEME_BASE_KEY`)*                                                                                                                                   | `hicyan / cyan`
 |                                      |         |                                                                                                                                                                                                                                                     |
@@ -577,11 +577,11 @@ theme:
     warning: yellow # (color) used in status keywords, e.g "Terminating" (fallback to theme.base.warning)
     error: red # (color) used in status keywords, e.g "Failed", "Unhealthy" (fallback to theme.base.danger)
   table:
-    header: fg=white:#aaff00 # (color) used on table headers (fallback to theme.base.info)
+    header: bold # (color) used on table headers (fallback to theme.base.info)
     columns: white / cyan # (color[]) used on table columns when no other coloring applies such as status or duration coloring. The multiple colors are cycled based on column ID, from left to right. (fallback to [theme.base.info / theme.base.secondary])
   stderr:
     default: white # (color) default when no specific mapping is found for the output line (fallback to theme.base.info)
-    error: fg=hi-yellow:bg=red:bold # (color) e.g when text contains "error" (fallback to theme.base.danger)
+    error: red # (color) e.g when text contains "error" (fallback to theme.base.danger)
   describe:
     key: hicyan / cyan # (color[]) used on keys. The multiple colors are cycled based on indentation. (fallback to theme.base.key)
   apply:

--- a/README.md
+++ b/README.md
@@ -205,9 +205,17 @@ For example, when you want to pass kubecolor result to grep (`kubecolor get pods
 
 When you don't want to colorize output, you can specify `--plain`. Kubecolor understands this option and outputs the result without colorizing.
 
-* `--pager`
+* `--no-paging`
 
-Pipe the output of the `get` and `describe` subcommands to a pager. Kubecolor tries a pager defined by `$KUBECOLOR_PAGER`, then `$PAGER` and then tries less and more. When using less, use `less -R` to pass color escape sequences and use `less -RF` to exit the pager if the file can be displayed on the first screen.
+Disable piping the output to a pager.
+
+* `--paging`
+
+Enable piping the output of to a pager if this was disabled in the config file.
+
+* `--pager=cmd`
+
+Use `cmd` as the pager.
 
 ### ENV Variables
 
@@ -535,9 +543,8 @@ Example file (the values shows the default values):
 kubectl: kubectl # path to kubectl executable
 preset: dark # color theme preset
 objFreshThreshold: 0 # ages below this uses theme.data.durationfresh coloring
-pager:
-  enabled: false # whether to use a pager
-  cmd: # command to run as pager
+paging: always # whether to pipe supported subcommands to a pager ("always" or "never")
+pager: # the command to use as pager; default uses $PAGER, less, or more
 
 # Color theme options
 theme:

--- a/command/config.go
+++ b/command/config.go
@@ -18,7 +18,8 @@ type Config struct {
 	StdinOverride        string
 	ObjFreshThreshold    time.Duration
 	Theme                *config.Theme
-	Paging               *config.Paging
+	Pager                string
+	Paging               config.Paging
 
 	ArgsPassthrough []string
 }
@@ -92,11 +93,15 @@ func ResolveConfigViper(inputArgs []string, v *viper.Viper) (*Config, error) {
 		case "--kubecolor-theme":
 			v.Set(config.PresetKey, value)
 		case "--pager":
-			b, err := parseBoolFlag(flag, value)
-			if err != nil {
-				return nil, err
+			v.Set("pager", value)
+		case "--paging":
+			if value == "" {
+				v.Set("paging", config.PagingAlways)
+			} else {
+				v.Set("paging", value)
 			}
-			v.Set("pager.enabled", b)
+		case "--no-paging":
+			v.Set("paging", config.PagingNever)
 		default:
 			cfg.ArgsPassthrough = append(cfg.ArgsPassthrough, s)
 		}
@@ -109,7 +114,8 @@ func ResolveConfigViper(inputArgs []string, v *viper.Viper) (*Config, error) {
 	cfg.KubectlCmd = newCfg.Kubectl
 	cfg.ObjFreshThreshold = newCfg.ObjFreshThreshold
 	cfg.Theme = &newCfg.Theme
-	cfg.Paging = &newCfg.Paging
+	cfg.Paging = newCfg.Paging
+	cfg.Pager = newCfg.Pager
 
 	return cfg, nil
 }

--- a/command/config.go
+++ b/command/config.go
@@ -96,12 +96,14 @@ func ResolveConfigViper(inputArgs []string, v *viper.Viper) (*Config, error) {
 			v.Set("pager", value)
 		case "--paging":
 			if value == "" {
-				v.Set("paging", config.PagingAuto)
+				// mapstructure doesn't like "type X string" values,
+				// so we have to convert it via string(...)
+				v.Set("paging", string(config.PagingAuto))
 			} else {
 				v.Set("paging", value)
 			}
 		case "--no-paging":
-			v.Set("paging", config.PagingNever)
+			v.Set("paging", string(config.PagingNever))
 		default:
 			cfg.ArgsPassthrough = append(cfg.ArgsPassthrough, s)
 		}

--- a/command/config.go
+++ b/command/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	ObjFreshThreshold    time.Duration
 	Theme                *config.Theme
 	Pager                bool
+	PagerCmd             string
 
 	ArgsPassthrough []string
 }
@@ -109,6 +110,7 @@ func ResolveConfigViper(inputArgs []string, v *viper.Viper) (*Config, error) {
 	cfg.KubectlCmd = newCfg.Kubectl
 	cfg.ObjFreshThreshold = newCfg.ObjFreshThreshold
 	cfg.Theme = &newCfg.Theme
+	cfg.PagerCmd = newCfg.Pager
 
 	return cfg, nil
 }

--- a/command/config.go
+++ b/command/config.go
@@ -96,7 +96,7 @@ func ResolveConfigViper(inputArgs []string, v *viper.Viper) (*Config, error) {
 			v.Set("pager", value)
 		case "--paging":
 			if value == "" {
-				v.Set("paging", config.PagingAlways)
+				v.Set("paging", config.PagingAuto)
 			} else {
 				v.Set("paging", value)
 			}

--- a/command/config.go
+++ b/command/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	StdinOverride        string
 	ObjFreshThreshold    time.Duration
 	Theme                *config.Theme
+	Pager                bool
 
 	ArgsPassthrough []string
 }
@@ -90,6 +91,12 @@ func ResolveConfigViper(inputArgs []string, v *viper.Viper) (*Config, error) {
 			cfg.StdinOverride = value
 		case "--kubecolor-theme":
 			v.Set(config.PresetKey, value)
+		case "--pager":
+			b, err := parseBoolFlag(flag, value)
+			if err != nil {
+				return nil, err
+			}
+			cfg.Pager = b
 		default:
 			cfg.ArgsPassthrough = append(cfg.ArgsPassthrough, s)
 		}

--- a/command/config.go
+++ b/command/config.go
@@ -18,8 +18,7 @@ type Config struct {
 	StdinOverride        string
 	ObjFreshThreshold    time.Duration
 	Theme                *config.Theme
-	Pager                bool
-	PagerCmd             string
+	Paging               *config.Paging
 
 	ArgsPassthrough []string
 }
@@ -97,7 +96,7 @@ func ResolveConfigViper(inputArgs []string, v *viper.Viper) (*Config, error) {
 			if err != nil {
 				return nil, err
 			}
-			cfg.Pager = b
+			v.Set("pager.enabled", b)
 		default:
 			cfg.ArgsPassthrough = append(cfg.ArgsPassthrough, s)
 		}
@@ -110,7 +109,7 @@ func ResolveConfigViper(inputArgs []string, v *viper.Viper) (*Config, error) {
 	cfg.KubectlCmd = newCfg.Kubectl
 	cfg.ObjFreshThreshold = newCfg.ObjFreshThreshold
 	cfg.Theme = &newCfg.Theme
-	cfg.PagerCmd = newCfg.Pager
+	cfg.Paging = &newCfg.Paging
 
 	return cfg, nil
 }

--- a/command/config_test.go
+++ b/command/config_test.go
@@ -21,7 +21,7 @@ func Test_ResolveConfig(t *testing.T) {
 			name: "no config",
 			args: []string{"get", "pods"},
 			expectedConf: &Config{
-				Paging:            config.PagingAlways,
+				Paging:            config.PagingAuto,
 				Plain:             false,
 				ForceColor:        false,
 				KubectlCmd:        "kubectl",
@@ -34,7 +34,7 @@ func Test_ResolveConfig(t *testing.T) {
 			name: "plain, light, force",
 			args: []string{"get", "pods", "--plain", "--light-background", "--force-colors"},
 			expectedConf: &Config{
-				Paging:            config.PagingAlways,
+				Paging:            config.PagingAuto,
 				Plain:             true,
 				ForceColor:        true,
 				KubectlCmd:        "kubectl",
@@ -48,7 +48,7 @@ func Test_ResolveConfig(t *testing.T) {
 			args: []string{"get", "pods", "--plain"},
 			env:  map[string]string{"KUBECTL_COMMAND": "kubectl.1.19"},
 			expectedConf: &Config{
-				Paging:            config.PagingAlways,
+				Paging:            config.PagingAuto,
 				Plain:             true,
 				ForceColor:        false,
 				KubectlCmd:        "kubectl.1.19",
@@ -62,7 +62,7 @@ func Test_ResolveConfig(t *testing.T) {
 			args: []string{"get", "pods"},
 			env:  map[string]string{"KUBECOLOR_OBJ_FRESH": "1m"},
 			expectedConf: &Config{
-				Paging:            config.PagingAlways,
+				Paging:            config.PagingAuto,
 				Plain:             false,
 				ForceColor:        false,
 				KubectlCmd:        "kubectl",
@@ -76,7 +76,7 @@ func Test_ResolveConfig(t *testing.T) {
 			args: []string{"get", "pods"},
 			env:  map[string]string{"KUBECOLOR_LIGHT_BACKGROUND": "true"},
 			expectedConf: &Config{
-				Paging:          config.PagingAlways,
+				Paging:          config.PagingAuto,
 				Plain:           false,
 				ForceColor:      false,
 				KubectlCmd:      "kubectl",
@@ -89,7 +89,7 @@ func Test_ResolveConfig(t *testing.T) {
 			args: []string{"get", "pods"},
 			env:  map[string]string{"KUBECOLOR_FORCE_COLORS": "true"},
 			expectedConf: &Config{
-				Paging:          config.PagingAlways,
+				Paging:          config.PagingAuto,
 				Plain:           false,
 				ForceColor:      true,
 				KubectlCmd:      "kubectl",
@@ -109,7 +109,7 @@ func Test_ResolveConfig(t *testing.T) {
 				KubectlCmd:      "kubectl",
 				Theme:           testconfig.DarkTheme,
 				Pager:           "most",
-				Paging:          config.PagingAlways,
+				Paging:          config.PagingAuto,
 			},
 		},
 		{

--- a/command/config_test.go
+++ b/command/config_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kubecolor/kubecolor/config"
 	"github.com/kubecolor/kubecolor/config/testconfig"
 	"github.com/kubecolor/kubecolor/testutil"
 )
@@ -20,6 +21,7 @@ func Test_ResolveConfig(t *testing.T) {
 			name: "no config",
 			args: []string{"get", "pods"},
 			expectedConf: &Config{
+				Paging:            config.PagingAlways,
 				Plain:             false,
 				ForceColor:        false,
 				KubectlCmd:        "kubectl",
@@ -32,6 +34,7 @@ func Test_ResolveConfig(t *testing.T) {
 			name: "plain, light, force",
 			args: []string{"get", "pods", "--plain", "--light-background", "--force-colors"},
 			expectedConf: &Config{
+				Paging:            config.PagingAlways,
 				Plain:             true,
 				ForceColor:        true,
 				KubectlCmd:        "kubectl",
@@ -45,6 +48,7 @@ func Test_ResolveConfig(t *testing.T) {
 			args: []string{"get", "pods", "--plain"},
 			env:  map[string]string{"KUBECTL_COMMAND": "kubectl.1.19"},
 			expectedConf: &Config{
+				Paging:            config.PagingAlways,
 				Plain:             true,
 				ForceColor:        false,
 				KubectlCmd:        "kubectl.1.19",
@@ -58,6 +62,7 @@ func Test_ResolveConfig(t *testing.T) {
 			args: []string{"get", "pods"},
 			env:  map[string]string{"KUBECOLOR_OBJ_FRESH": "1m"},
 			expectedConf: &Config{
+				Paging:            config.PagingAlways,
 				Plain:             false,
 				ForceColor:        false,
 				KubectlCmd:        "kubectl",
@@ -71,6 +76,7 @@ func Test_ResolveConfig(t *testing.T) {
 			args: []string{"get", "pods"},
 			env:  map[string]string{"KUBECOLOR_LIGHT_BACKGROUND": "true"},
 			expectedConf: &Config{
+				Paging:          config.PagingAlways,
 				Plain:           false,
 				ForceColor:      false,
 				KubectlCmd:      "kubectl",
@@ -83,11 +89,40 @@ func Test_ResolveConfig(t *testing.T) {
 			args: []string{"get", "pods"},
 			env:  map[string]string{"KUBECOLOR_FORCE_COLORS": "true"},
 			expectedConf: &Config{
+				Paging:          config.PagingAlways,
 				Plain:           false,
 				ForceColor:      true,
 				KubectlCmd:      "kubectl",
 				Theme:           testconfig.DarkTheme,
 				ArgsPassthrough: []string{"get", "pods"},
+			},
+		},
+		{
+			name: "Pager flags overwrite (1)",
+			args: []string{"--paging", "--pager=most", "get", "pods"},
+			env: map[string]string{
+				"KUBECOLOR_PAGING": "never",
+				"KUBECOLOR_PAGER":  "more",
+			},
+			expectedConf: &Config{
+				ArgsPassthrough: []string{"get", "pods"},
+				KubectlCmd:      "kubectl",
+				Theme:           testconfig.DarkTheme,
+				Pager:           "most",
+				Paging:          config.PagingAlways,
+			},
+		},
+		{
+			name: "Pager flags overwrite (2)",
+			args: []string{"--no-paging", "get", "pods"},
+			env: map[string]string{
+				"KUBECOLOR_PAGING": "always",
+			},
+			expectedConf: &Config{
+				ArgsPassthrough: []string{"get", "pods"},
+				KubectlCmd:      "kubectl",
+				Theme:           testconfig.DarkTheme,
+				Paging:          config.PagingNever,
 			},
 		},
 	}

--- a/command/config_test.go
+++ b/command/config_test.go
@@ -116,7 +116,7 @@ func Test_ResolveConfig(t *testing.T) {
 			name: "Pager flags overwrite (2)",
 			args: []string{"--no-paging", "get", "pods"},
 			env: map[string]string{
-				"KUBECOLOR_PAGING": "always",
+				"KUBECOLOR_PAGING": string(config.PagingAuto),
 			},
 			expectedConf: &Config{
 				ArgsPassthrough: []string{"get", "pods"},

--- a/command/runner.go
+++ b/command/runner.go
@@ -19,7 +19,7 @@ import (
 var (
 	Stdout = colorable.NewColorableStdout()
 	Stderr = colorable.NewColorableStderr()
-	DefaultPagers = []string{"pager", "less", "more"}
+	DefaultPagers = []string{"less", "more"}
 )
 
 type Printers struct {
@@ -245,6 +245,9 @@ func runPager() (*pagerPipe, error) {
 		for _, p := range DefaultPagers {
 			if _, err := exec.LookPath(p); err == nil {
 				pager = p
+				if pager == "less" {
+					pager = "less -R"
+				}
 				break
 			}
 		}

--- a/command/runner.go
+++ b/command/runner.go
@@ -17,8 +17,8 @@ import (
 )
 
 var (
-	Stdout = colorable.NewColorableStdout()
-	Stderr = colorable.NewColorableStderr()
+	Stdout        = colorable.NewColorableStdout()
+	Stderr        = colorable.NewColorableStderr()
 	DefaultPagers = []string{"less", "more"}
 )
 
@@ -71,7 +71,7 @@ func Run(args []string, version string) error {
 	if config.Pager && isOutputTerminal() &&
 		(subcmd == kubectl.Get || subcmd == kubectl.Describe ||
 			subcmd == kubectl.Logs || subcmd == kubectl.Explain) {
-		pipe, err := runPager()
+		pipe, err := runPager(config.PagerCmd)
 		if err != nil {
 			err = fmt.Errorf("failed to run pager: %w", err)
 			fmt.Fprintf(os.Stderr, "[kubecolor] [ERROR] %v\n", err)
@@ -235,9 +235,11 @@ func (p pagerPipe) Write(b []byte) (int, error) {
 	return p.writer.Write(b)
 }
 
-func runPager() (*pagerPipe, error) {
+func runPager(pagerCmd string) (*pagerPipe, error) {
 	pager := ""
-	if p := os.Getenv("KUBECOLOR_PAGER"); p != "" {
+	if pagerCmd != "" {
+		pager = pagerCmd
+	} else if p := os.Getenv("KUBECOLOR_PAGER"); p != "" {
 		pager = p
 	} else if p := os.Getenv("PAGER"); p != "" {
 		pager = p

--- a/command/runner.go
+++ b/command/runner.go
@@ -68,7 +68,8 @@ func Run(args []string, version string) error {
 
 	subcmd := subcommandInfo.Subcommand
 	if config.Pager && isOutputTerminal() &&
-		(subcmd == kubectl.Get || subcmd == kubectl.Describe) {
+		(subcmd == kubectl.Get || subcmd == kubectl.Describe ||
+			subcmd == kubectl.Logs || subcmd == kubectl.Explain) {
 		pipe, err := runPager()
 		if err != nil {
 			err = fmt.Errorf("failed to run pager: %w", err)

--- a/command/runner.go
+++ b/command/runner.go
@@ -63,7 +63,7 @@ func Run(args []string, version string) error {
 
 	subcmd := subcommandInfo.Subcommand
 	if config.Pager && isOutputTerminal() &&
-	   (subcmd == kubectl.Get || subcmd == kubectl.Describe) {
+		(subcmd == kubectl.Get || subcmd == kubectl.Describe) {
 		closePager, err := runPager()
 		if err != nil {
 			err = fmt.Errorf("failed to run pager: %w", err)

--- a/command/runner.go
+++ b/command/runner.go
@@ -236,7 +236,7 @@ func defaultPager() string {
 		return p
 	}
 	if _, err := exec.LookPath("less"); err == nil {
-		return "less -R"
+		return "less -RF"
 	}
 	if _, err := exec.LookPath("more"); err == nil {
 		return "more"
@@ -245,10 +245,8 @@ func defaultPager() string {
 }
 
 func runPager(pagerCmd string) (*pagerPipe, error) {
-	var pager string
-	if pagerCmd != "" {
-		pager = pagerCmd
-	} else {
+	pager := pagerCmd
+	if pagerCmd == "" {
 		pager = defaultPager()
 	}
 

--- a/command/runner.go
+++ b/command/runner.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kubecolor/kubecolor/config"
+	kcconfig "github.com/kubecolor/kubecolor/config"
 	"github.com/kubecolor/kubecolor/kubectl"
 	"github.com/kubecolor/kubecolor/printer"
 	"github.com/mattn/go-colorable"
@@ -32,7 +32,7 @@ type pagerPipe struct {
 }
 
 // This is defined here to be replaced in test
-var getPrinters = func(subcommandInfo *kubectl.SubcommandInfo, objFreshThreshold time.Duration, theme *config.Theme) *Printers {
+var getPrinters = func(subcommandInfo *kubectl.SubcommandInfo, objFreshThreshold time.Duration, theme *kcconfig.Theme) *Printers {
 	return &Printers{
 		FullColoredPrinter: &printer.KubectlOutputColoredPrinter{
 			SubcommandInfo:    subcommandInfo,
@@ -41,7 +41,7 @@ var getPrinters = func(subcommandInfo *kubectl.SubcommandInfo, objFreshThreshold
 			Theme:             theme,
 		},
 		ErrorPrinter: &printer.WithFuncPrinter{
-			Fn: func(line string) config.Color {
+			Fn: func(line string) kcconfig.Color {
 				if strings.HasPrefix(strings.ToLower(line), "error") {
 					return theme.Stderr.Error
 				}
@@ -66,8 +66,8 @@ func Run(args []string, version string) error {
 
 	shouldColorize, subcommandInfo := ResolveSubcommand(args, config)
 
-	if config.Paging.Enabled && isOutputTerminal() && subcommandInfo.SupportsPager() {
-		pipe, err := runPager(config.Paging.Cmd)
+	if config.Paging==kcconfig.PagingAlways && isOutputTerminal() && subcommandInfo.SupportsPager() {
+		pipe, err := runPager(config.Pager)
 		if err != nil {
 			err = fmt.Errorf("failed to run pager: %w", err)
 			fmt.Fprintf(os.Stderr, "[kubecolor] [ERROR] %v\n", err)

--- a/command/runner.go
+++ b/command/runner.go
@@ -64,12 +64,12 @@ func Run(args []string, version string) error {
 	subcmd := subcommandInfo.Subcommand
 	if config.Pager && isOutputTerminal() &&
 		(subcmd == kubectl.Get || subcmd == kubectl.Describe) {
-		closePager, err := runPager()
+		wait, err := runPager()
 		if err != nil {
 			err = fmt.Errorf("failed to run pager: %w", err)
 			fmt.Fprintf(os.Stderr, "[kubecolor] [ERROR] %v\n", err)
 		} else {
-			defer closePager()
+			defer wait()
 		}
 	}
 

--- a/command/runner.go
+++ b/command/runner.go
@@ -66,7 +66,7 @@ func Run(args []string, version string) error {
 
 	shouldColorize, subcommandInfo := ResolveSubcommand(args, cfg)
 
-	if cfg.Paging==config.PagingAuto && isOutputTerminal() && subcommandInfo.SupportsPager() {
+	if cfg.Paging == config.PagingAuto && isOutputTerminal() && subcommandInfo.SupportsPager() {
 		pipe, err := runPager(cfg.Pager)
 		if err != nil {
 			err = fmt.Errorf("failed to run pager: %w", err)

--- a/config-schema.json
+++ b/config-schema.json
@@ -376,8 +376,8 @@
     },
     "paging": {
       "type": "string",
-      "description": "Whether to enable paging: \"always\" or \"never\"",
-      "default": "always"
+      "description": "Whether to enable paging: \"auto\" or \"never\"",
+      "default": "auto"
     }
   },
   "additionalProperties": false,

--- a/config-schema.json
+++ b/config-schema.json
@@ -49,6 +49,16 @@
         "5h"
       ]
     },
+    "paging": {
+      "type": "string",
+      "enum": [
+        "auto",
+        "never"
+      ],
+      "title": "Paging mode preference",
+      "description": "Whether to pipe supported subcommands to a pager (\"auto\" or \"never\")",
+      "default": "auto"
+    },
     "preset": {
       "type": "string",
       "enum": [
@@ -372,12 +382,15 @@
     },
     "pager": {
       "type": "string",
-      "description": "Command to use as pager"
+      "description": "Command to use as pager",
+      "examples": [
+        "less -RF",
+        "more"
+      ]
     },
     "paging": {
-      "type": "string",
-      "description": "Whether to enable paging: \"auto\" or \"never\"",
-      "default": "auto"
+      "$ref": "#/$defs/paging",
+      "description": "Whether to enable paging: \"auto\" or \"never\""
     }
   },
   "additionalProperties": false,

--- a/config-schema.json
+++ b/config-schema.json
@@ -369,6 +369,15 @@
     },
     "theme": {
       "$ref": "#/$defs/theme"
+    },
+    "pager": {
+      "type": "string",
+      "description": "Command to use as pager"
+    },
+    "paging": {
+      "type": "string",
+      "description": "Whether to enable paging: \"always\" or \"never\"",
+      "default": "always"
     }
   },
   "additionalProperties": false,

--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	ObjFreshThreshold time.Duration // Ages below this uses theme.data.durationfresh coloring
 	Preset            Preset        // Color theme preset
 	Theme             Theme
-	Pager             string
+	Pager             string        // Command to execute as pager
 }
 
 func NewViper() *viper.Viper {

--- a/config/config.go
+++ b/config/config.go
@@ -17,8 +17,8 @@ import (
 const PresetKey = "preset"
 
 const (
-	PagingAuto Paging = "auto"
-	PagingNever  Paging = "never"
+	PagingAuto  Paging = "auto"
+	PagingNever Paging = "never"
 )
 
 // PagingOptions can be used for validation and schema generation (not implemented)

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	ObjFreshThreshold time.Duration // Ages below this uses theme.data.durationfresh coloring
 	Preset            Preset        // Color theme preset
 	Theme             Theme
+	Pager             string
 }
 
 func NewViper() *viper.Viper {

--- a/config/config.go
+++ b/config/config.go
@@ -16,23 +16,6 @@ import (
 // PresetKey is the Viper config key to use in [viper.Viper.Set].
 const PresetKey = "preset"
 
-const (
-	PagingAuto  Paging = "auto"
-	PagingNever Paging = "never"
-
-	PagingDefault = PagingAuto
-)
-
-// AllPagingModes can be used for validation and schema generation (not implemented)
-var (
-	AllPagingModes []Paging = []Paging{
-		PagingAuto,
-		PagingNever,
-	}
-)
-
-type Paging string
-
 type Config struct {
 	Debug             bool          `jsonschema:"-"`
 	Kubectl           string        `jsonschema:"default=kubectl,example=kubectl1.19,example=oc"` // Which kubectl executable to use
@@ -61,7 +44,7 @@ func NewViper() *viper.Viper {
 	v.SetDefault("kubectl", "kubectl")
 	// mapstructure doesn't like "type X string" values, so we have to convert it via string(...)
 	v.SetDefault(PresetKey, string(PresetDefault))
-	v.SetDefault("paging", PagingDefault)
+	v.SetDefault("paging", string(PagingDefault))
 	v.SetDefault("pager", defaultPager())
 
 	return v

--- a/config/config.go
+++ b/config/config.go
@@ -19,11 +19,13 @@ const PresetKey = "preset"
 const (
 	PagingAuto  Paging = "auto"
 	PagingNever Paging = "never"
+
+	PagingDefault = PagingAuto
 )
 
-// PagingOptions can be used for validation and schema generation (not implemented)
+// AllPagingModes can be used for validation and schema generation (not implemented)
 var (
-	PagingOptions []Paging = []Paging{
+	AllPagingModes []Paging = []Paging{
 		PagingAuto,
 		PagingNever,
 	}
@@ -37,8 +39,8 @@ type Config struct {
 	ObjFreshThreshold time.Duration // Ages below this uses theme.data.durationfresh coloring
 	Preset            Preset        // Color theme preset
 	Theme             Theme         //
-	Pager             string        // Command to use as pager
-	Paging            Paging        `jsonschema:"default=auto"` // Whether to enable paging: "auto" or "never"
+	Pager             string        `jsonschema:"example=less -RF,less --RAW-CONTROL-CHARS --quit-if-one-screen,example=more"` // Command to use as pager
+	Paging            Paging        `jsonschema:"default=auto"`                                                                // Whether to enable paging: "auto" or "never"
 }
 
 func NewViper() *viper.Viper {
@@ -59,7 +61,7 @@ func NewViper() *viper.Viper {
 	v.SetDefault("kubectl", "kubectl")
 	// mapstructure doesn't like "type X string" values, so we have to convert it via string(...)
 	v.SetDefault(PresetKey, string(PresetDefault))
-	v.SetDefault("paging", PagingAuto)
+	v.SetDefault("paging", PagingDefault)
 	v.SetDefault("pager", defaultPager())
 
 	return v

--- a/config/config.go
+++ b/config/config.go
@@ -15,13 +15,18 @@ import (
 // PresetKey is the Viper config key to use in [viper.Viper.Set].
 const PresetKey = "preset"
 
+type Paging struct {
+	Enabled bool   // Whether to enable the pager
+	Cmd     string // Command to execute as pager
+}
+
 type Config struct {
 	Debug             bool          `jsonschema:"-"`
 	Kubectl           string        `jsonschema:"default=kubectl,example=kubectl1.19,example=oc"` // Which kubectl executable to use
 	ObjFreshThreshold time.Duration // Ages below this uses theme.data.durationfresh coloring
 	Preset            Preset        // Color theme preset
 	Theme             Theme
-	Pager             string        // Command to execute as pager
+	Paging            Paging
 }
 
 func NewViper() *viper.Viper {
@@ -37,6 +42,8 @@ func NewViper() *viper.Viper {
 
 	v.MustBindEnv("kubectl", "KUBECTL_COMMAND")
 	v.MustBindEnv("objfreshthreshold", "KUBECOLOR_OBJ_FRESH")
+
+	v.BindEnv("paging.cmd", "KUBECOLOR_PAGER")
 
 	v.SetDefault("kubectl", "kubectl")
 	// mapstructure doesn't like "type X string" values, so we have to convert it via string(...)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,3 +30,28 @@ func TestEnvVars_theme(t *testing.T) {
 	testutil.Equal(t, Color{Source: "red", Code: "31"}, cfg.Theme.Table.Header, "Read from cfg.Theme.Table.Header")
 	testutil.Equal(t, "red", v.Get("theme.table.header"), "Read from v.Get(...)")
 }
+
+func TestEnvVars_pager(t *testing.T) {
+	v := NewViper()
+	os.Clearenv()
+
+	testutil.Setenv(t, "PAGER", "more")
+	cfg, err := Unmarshal(v)
+	testutil.MustNoError(t, err)
+	testutil.Equal(t, "", cfg.Pager)
+
+	testutil.Setenv(t, "KUBECOLOR_PAGER", "more")
+	cfg, err = Unmarshal(v)
+	testutil.MustNoError(t, err)
+	testutil.Equal(t, "more", cfg.Pager)
+
+	testutil.Setenv(t, "KUBECOLOR_PAGING", string(PagingNever))
+	cfg, err = Unmarshal(v)
+	testutil.MustNoError(t, err)
+	testutil.Equal(t, PagingNever, cfg.Paging)
+
+	testutil.Setenv(t, "KUBECOLOR_PAGING", string(PagingAlways))
+	cfg, err = Unmarshal(v)
+	testutil.MustNoError(t, err)
+	testutil.Equal(t, PagingAlways, cfg.Paging)
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -40,10 +40,10 @@ func TestEnvVars_pager(t *testing.T) {
 	testutil.MustNoError(t, err)
 	testutil.Equal(t, "", cfg.Pager)
 
-	testutil.Setenv(t, "KUBECOLOR_PAGER", "more")
+	testutil.Setenv(t, "KUBECOLOR_PAGER", "more2")
 	cfg, err = Unmarshal(v)
 	testutil.MustNoError(t, err)
-	testutil.Equal(t, "more", cfg.Pager)
+	testutil.Equal(t, "more2", cfg.Pager)
 
 	testutil.Setenv(t, "KUBECOLOR_PAGING", string(PagingNever))
 	cfg, err = Unmarshal(v)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -40,6 +40,11 @@ func TestEnvVars_pager(t *testing.T) {
 	testutil.MustNoError(t, err)
 	testutil.Equal(t, "", cfg.Pager)
 
+	v = NewViper() // this time with more as default pager
+	cfg, err = Unmarshal(v)
+	testutil.MustNoError(t, err)
+	testutil.Equal(t, "more", cfg.Pager)
+
 	testutil.Setenv(t, "KUBECOLOR_PAGER", "more2")
 	cfg, err = Unmarshal(v)
 	testutil.MustNoError(t, err)
@@ -50,8 +55,8 @@ func TestEnvVars_pager(t *testing.T) {
 	testutil.MustNoError(t, err)
 	testutil.Equal(t, PagingNever, cfg.Paging)
 
-	testutil.Setenv(t, "KUBECOLOR_PAGING", string(PagingAlways))
+	testutil.Setenv(t, "KUBECOLOR_PAGING", string(PagingAuto))
 	cfg, err = Unmarshal(v)
 	testutil.MustNoError(t, err)
-	testutil.Equal(t, PagingAlways, cfg.Paging)
+	testutil.Equal(t, PagingAuto, cfg.Paging)
 }

--- a/config/paging.go
+++ b/config/paging.go
@@ -1,0 +1,63 @@
+package config
+
+import (
+	"encoding"
+	"fmt"
+	"strings"
+)
+
+type Paging string
+
+const (
+	// NOTE: When adding paging modes, remember to add them to [AllPagingModes] slice too.
+
+	PagingAuto  Paging = "auto"
+	PagingNever Paging = "never"
+)
+
+var (
+	PagingDefault = PagingAuto
+
+	AllPagingModes []Paging = []Paging{
+		PagingAuto,
+		PagingNever,
+	}
+
+	_ encoding.TextMarshaler   = PagingDefault
+	_ encoding.TextUnmarshaler = &PagingDefault
+)
+
+func (p Paging) String() string {
+	if p == "" {
+		return "auto"
+	}
+	return string(p)
+}
+
+func ParsePaging(s string) (Paging, error) {
+	if s == "" {
+		return PagingAuto, nil
+	}
+	maybeValidPaging := Paging(strings.ToLower(s))
+	for _, p := range AllPagingModes {
+		if maybeValidPaging == p {
+			return p, nil // reuse the interned string
+		}
+	}
+	return PagingAuto, fmt.Errorf("invalid paging mode: %q", s)
+}
+
+// MarshalText implements [encoding.TextMarshaler].
+func (p Paging) MarshalText() (text []byte, err error) {
+	return []byte(p.String()), nil
+}
+
+// UnmarshalText implements [encoding.TextUnmarshaler].
+func (p *Paging) UnmarshalText(text []byte) error {
+	newPaging, err := ParsePaging(string(text))
+	if err != nil {
+		return err
+	}
+	*p = newPaging
+	return nil
+}

--- a/coverage.txt
+++ b/coverage.txt
@@ -1,0 +1,1 @@
+mode: atomic

--- a/coverage.txt
+++ b/coverage.txt
@@ -1,1 +1,0 @@
-mode: atomic

--- a/internal/cmd/configschema/main.go
+++ b/internal/cmd/configschema/main.go
@@ -88,7 +88,15 @@ func main() {
 		Title:       "Color theme preset",
 		Description: "Preset is a set of defaults for the color theme.",
 		Default:     config.PresetDefault.String(),
-		Enum:        allPresets(),
+		Enum:        castToAnySlice(config.AllPresets),
+	}
+
+	s.Definitions["paging"] = &jsonschema.Schema{
+		Type:        "string",
+		Title:       "Paging mode preference",
+		Description: "Whether to pipe supported subcommands to a pager (\"auto\" or \"never\")",
+		Default:     string(config.PagingDefault),
+		Enum:        castToAnySlice(config.AllPagingModes),
 	}
 
 	s.Definitions["duration"] = &jsonschema.Schema{
@@ -125,10 +133,9 @@ func main() {
 	}
 }
 
-func allPresets() []any {
-	all := config.AllPresets
-	slice := make([]any, len(all))
-	for i, v := range all {
+func castToAnySlice[E any](s []E) []any {
+	slice := make([]any, len(s))
+	for i, v := range s {
 		slice[i] = v
 	}
 	return slice
@@ -138,7 +145,7 @@ func allPresets() []any {
 // types to Schema IDs.
 func Lookup(t reflect.Type) jsonschema.ID {
 	switch t.Name() {
-	case "Color", "ColorSlice", "Preset", "Duration":
+	case "Color", "ColorSlice", "Preset", "Paging", "Duration":
 		return jsonschema.ID("#/$defs/" + Namer(t.Name()))
 	default:
 		return ""

--- a/kubectl/subcommand.go
+++ b/kubectl/subcommand.go
@@ -10,6 +10,7 @@ type SubcommandInfo struct {
 	FormatOption FormatOption
 	NoHeader     bool
 	Watch        bool
+	Follow       bool
 	Help         bool
 	Recursive    bool
 	Client       bool
@@ -213,6 +214,8 @@ func CollectCommandlineOptions(args []string, info *SubcommandInfo) {
 			info.NoHeader = true
 		} else if args[i] == "-w" || args[i] == "--watch" {
 			info.Watch = true
+		} else if args[i] == "-f" || args[i] == "--follow" {
+			info.Follow = true
 		} else if args[i] == "--recursive=true" || args[i] == "--recursive" {
 			info.Recursive = true
 		} else if args[i] == "-h" || args[i] == "--help" {

--- a/kubectl/subcommand.go
+++ b/kubectl/subcommand.go
@@ -246,9 +246,11 @@ func InspectSubcommandInfo(args []string) (*SubcommandInfo, bool) {
 
 func (sci *SubcommandInfo) SupportsPager() bool {
 	switch sci.Subcommand {
-	case Get,
-		Describe,
-		Logs,
+	case Get:
+		return !sci.Watch
+	case Logs:
+		return !sci.Follow
+	case Describe,
 		Explain:
 		return true
 	}

--- a/kubectl/subcommand.go
+++ b/kubectl/subcommand.go
@@ -246,13 +246,10 @@ func InspectSubcommandInfo(args []string) (*SubcommandInfo, bool) {
 
 func (sci *SubcommandInfo) SupportsPager() bool {
 	switch sci.Subcommand {
-	case Get:
-		return true
-	case Describe:
-		return true
-	case Logs:
-		return true
-	case Explain:
+	case Get,
+		Describe,
+		Logs,
+		Explain:
 		return true
 	}
 	return false

--- a/kubectl/subcommand.go
+++ b/kubectl/subcommand.go
@@ -243,3 +243,17 @@ func InspectSubcommandInfo(args []string) (*SubcommandInfo, bool) {
 
 	return ret, false
 }
+
+func (sci *SubcommandInfo) SupportsPager() bool {
+	switch sci.Subcommand {
+	case Get:
+		return true
+	case Describe:
+		return true
+	case Logs:
+		return true
+	case Explain:
+		return true
+	}
+	return false
+}

--- a/kubectl/subcommand.go
+++ b/kubectl/subcommand.go
@@ -248,6 +248,9 @@ func InspectSubcommandInfo(args []string) (*SubcommandInfo, bool) {
 }
 
 func (sci *SubcommandInfo) SupportsPager() bool {
+	if sci.Help {
+		return false
+	}
 	switch sci.Subcommand {
 	case Get:
 		return !sci.Watch

--- a/kubectl/subcommand.go
+++ b/kubectl/subcommand.go
@@ -212,7 +212,7 @@ func CollectCommandlineOptions(args []string, info *SubcommandInfo) {
 			}
 		} else if args[i] == "--no-headers" {
 			info.NoHeader = true
-		} else if args[i] == "-w" || args[i] == "--watch" {
+		} else if args[i] == "-w" || args[i] == "--watch" || args[i] == "--watch-only" {
 			info.Watch = true
 		} else if args[i] == "-f" || args[i] == "--follow" {
 			info.Follow = true


### PR DESCRIPTION
# Description

Pipe the output of the `get` and `describe` subcommands to a pager.

Example usage:
```
PAGER="less -RF" ./kubecolor --pager get po -A
```

I have only tested this on Linux. I'm hoping someone else can test on Windows.

## Type of change

Please delete options that are not relevant.
 
- [x] New feature (non-breaking change which adds functionality)