### PR TITLE
Fix detection of 'oc rsh'

### DIFF
--- a/command/subcommand_test.go
+++ b/command/subcommand_test.go
@@ -109,7 +109,7 @@ func Test_ResolveSubcommand(t *testing.T) {
 			expectedInfo:           &kubectl.SubcommandInfo{Subcommand: kubectl.Get},
 		},
 		{
-			name:             "when the subcommand is unsupported, it won't colorize",
+			name:             "when the subcommand is help, it will colorize",
 			args:             []string{"-h"},
 			isOutputTerminal: func() bool { return true },
 			conf: &Config{
@@ -120,6 +120,19 @@ func Test_ResolveSubcommand(t *testing.T) {
 			},
 			expectedShouldColorize: true,
 			expectedInfo:           &kubectl.SubcommandInfo{Help: true},
+		},
+		{
+			name:             "when the subcommand is unsupported, it won't colorize",
+			args:             []string{"rsh"},
+			isOutputTerminal: func() bool { return true },
+			conf: &Config{
+				Plain:      false,
+				ForceColor: false,
+				KubectlCmd: "kubectl",
+				Theme:      testconfig.DarkTheme,
+			},
+			expectedShouldColorize: false,
+			expectedInfo:           &kubectl.SubcommandInfo{Subcommand: kubectl.Rsh},
 		},
 	}
 	for _, tt := range tests {

--- a/kubectl/subcommand.go
+++ b/kubectl/subcommand.go
@@ -123,6 +123,7 @@ func InspectSubcommand(command string) (Subcommand, bool) {
 		Proxy,
 		Replace,
 		Rollout,
+		Rsh,
 		Run,
 		Scale,
 		Set,

--- a/kubectl/subcommand_test.go
+++ b/kubectl/subcommand_test.go
@@ -60,6 +60,8 @@ func TestInspectSubcommandInfo(t *testing.T) {
 
 		{"apply", &SubcommandInfo{Subcommand: Apply}, true},
 
+		{"rsh", &SubcommandInfo{Subcommand: Rsh}, true},
+
 		{"", &SubcommandInfo{}, false},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
# Description

Fixes detection of `oc rsh`. Kubecolor was properly configured to not colorize the command, but it was not configured to detect that `oc rsh` was the "Rsh` subcommand.

Silly derp from me when I tried fixing this before in #117

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## What you changed

- Added `oc rsh` subcommand detection
- Added tests for subcommand detection

## Why you think we should change it

Fixes bug

## Related issue (if exists)

Closes #108
