### PR TITLE
Added colorization of help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,11 @@ colors of your output.
 |                                      |         |                                                                                                                                                                                                                                                     |
 | `KUBECOLOR_THEME_DEFAULT`            | color   | default when no specific mapping is found for the command                                                                                                                                                                                           | `green`
 |                                      |         |                                                                                                                                                                                                                                                     |
+| `KUBECOLOR_THEME_SHELL_COMMENT`      | color   | used on comments, e.g `# this is a comment`<br/>*(fallback to `KUBECOLOR_THEME_BASE_MUTED`)*                                                                                                                                                        | `gray:italic`
+| `KUBECOLOR_THEME_SHELL_COMMAND`      | color   | used on commands, e.g `kubectl` or `echo`<br/>*(fallback to `KUBECOLOR_THEME_BASE_SUCCESS`)*                                                                                                                                                        | `green`
+| `KUBECOLOR_THEME_SHELL_ARG`          | color   | used on arguments, e.g `get pods` in `kubectl get pods`<br/>*(fallback to `KUBECOLOR_THEME_BASE_INFO`)*                                                                                                                                             | `white`
+| `KUBECOLOR_THEME_SHELL_FLAG`         | color   | used on flags, e.g `--watch` in `kubectl get pods --watch`<br/>*(fallback to `KUBECOLOR_THEME_BASE_SECONDARY`)*                                                                                                                                     | `cyan`
+|                                      |         |                                                                                                                                                                                                                                                     |
 | `KUBECOLOR_THEME_DATA_KEY`           | color[] | used for the key<br/>*(fallback to `KUBECOLOR_THEME_BASE_KEY`)*                                                                                                                                                                                     | `hicyan / cyan`
 | `KUBECOLOR_THEME_DATA_STRING`        | color   | used when value is a string<br/>*(fallback to `KUBECOLOR_THEME_BASE_INFO`)*                                                                                                                                                                         | `hiyellow`
 | `KUBECOLOR_THEME_DATA_TRUE`          | color   | used when value is true<br/>*(fallback to `KUBECOLOR_THEME_BASE_SUCCESS`)*                                                                                                                                                                          | `green`
@@ -404,6 +409,12 @@ colors of your output.
 | `KUBECOLOR_THEME_OPTIONS_FLAG`       | color   | e.g "--kubeconfig"<br/>*(fallback to `KUBECOLOR_THEME_BASE_SECONDARY`)*                                                                                                                                                                             | `cyan`
 |                                      |         |                                                                                                                                                                                                                                                     |
 | `KUBECOLOR_THEME_VERSION_KEY`        | color[] | used on the key<br/>*(fallback to `KUBECOLOR_THEME_BASE_KEY`)*                                                                                                                                                                                      | `hicyan / cyan`
+|                                      |         |                                                                                                                                                                                                                                                     |
+| `KUBECOLOR_THEME_HELP_HEADER`        | color   | e.g "Examples:" or "Options:"<br/>*(fallback to `KUBECOLOR_THEME_TABLE_HEADER`)*                                                                                                                                                                    | `bold`
+| `KUBECOLOR_THEME_HELP_FLAG`          | color   | e.g "--kubeconfig"<br/>*(fallback to `KUBECOLOR_THEME_BASE_SECONDARY`)*                                                                                                                                                                             | `cyan`
+| `KUBECOLOR_THEME_HELP_FLAGDESC`      | color   | Flag descripion under "Options:" heading<br/>*(fallback to `KUBECOLOR_THEME_BASE_INFO`)*                                                                                                                                                            | `white`
+| `KUBECOLOR_THEME_HELP_URL`           | color   | e.g `[https://example.com]`<br/>*(fallback to `KUBECOLOR_THEME_BASE_SECONDARY`)*                                                                                                                                                                    | `cyan`
+| `KUBECOLOR_THEME_HELP_TEXT`          | color   | Fallback text color<br/>*(fallback to `KUBECOLOR_THEME_BASE_INFO`)*                                                                                                                                                                                 | `white`
 
 ### Config type: `color`
 
@@ -558,6 +569,11 @@ theme:
     muted: gray:italic # (color) general color for when things are less relevant
     key: hicyan / cyan # (color[]) general color for keys (fallback to [theme.base.secondary])
   default: green # (color) default when no specific mapping is found for the command
+  shell:
+    comment: gray:italic # (color) used on comments, e.g `# this is a comment` (fallback to theme.base.muted)
+    command: green # (color) used on commands, e.g `kubectl` or `echo` (fallback to theme.base.success)
+    arg: white # (color) used on arguments, e.g `get pods` in `kubectl get pods` (fallback to theme.base.info)
+    flag: cyan # (color) used on flags, e.g `--watch` in `kubectl get pods --watch` (fallback to theme.base.secondary)
   data:
     key: hicyan / cyan # (color[]) used for the key (fallback to theme.base.key)
     string: hiyellow # (color) used when value is a string (fallback to theme.base.info)
@@ -597,6 +613,12 @@ theme:
     flag: cyan # (color) e.g "--kubeconfig" (fallback to theme.base.secondary)
   version:
     key: hicyan / cyan # (color[]) used on the key (fallback to theme.base.key)
+  help:
+    header: bold # (color) e.g "Examples:" or "Options:" (fallback to theme.table.header)
+    flag: cyan # (color) e.g "--kubeconfig" (fallback to theme.base.secondary)
+    flagdesc: white # (color) Flag descripion under "Options:" heading (fallback to theme.base.info)
+    url: cyan # (color) e.g `[https://example.com]` (fallback to theme.base.secondary)
+    text: white # (color) Fallback text color (fallback to theme.base.info)
 ```
 
 You can also override this using the `KUBECOLOR_CONFIG` environment variable:

--- a/command/subcommand.go
+++ b/command/subcommand.go
@@ -31,7 +31,7 @@ func ResolveSubcommand(args []string, config *Config) (bool, *kubectl.Subcommand
 	}
 
 	colorsSupported := isColoringSupported(subcommandInfo.Subcommand)
-	if !colorsSupported {
+	if !colorsSupported && !subcommandInfo.Help {
 		return false, subcommandInfo
 	}
 

--- a/command/subcommand.go
+++ b/command/subcommand.go
@@ -30,8 +30,7 @@ func ResolveSubcommand(args []string, config *Config) (bool, *kubectl.Subcommand
 		return true, subcommandInfo
 	}
 
-	colorsSupported := isColoringSupported(subcommandInfo.Subcommand)
-	if !colorsSupported && !subcommandInfo.Help {
+	if !subcommandInfo.SupportsColoring() {
 		return false, subcommandInfo
 	}
 
@@ -47,30 +46,3 @@ func ResolveSubcommand(args []string, config *Config) (bool, *kubectl.Subcommand
 	return subcommandFound, subcommandInfo
 }
 
-// when you add something here, it won't be colorized
-var unsupported = map[kubectl.Subcommand]struct{}{
-	kubectl.Attach:           {},
-	kubectl.Completion:       {},
-	kubectl.Create:           {},
-	kubectl.Ctx:              {},
-	kubectl.Debug:            {},
-	kubectl.Delete:           {},
-	kubectl.Edit:             {},
-	kubectl.Exec:             {},
-	kubectl.InternalComplete: {},
-	kubectl.KubectlPlugin:    {},
-	kubectl.Ns:               {},
-	kubectl.Plugin:           {},
-	kubectl.Proxy:            {},
-	kubectl.Replace:          {},
-	kubectl.Run:              {},
-	kubectl.Wait:             {},
-
-	// oc (OpenShift CLI) specific subcommands
-	kubectl.Rsh: {},
-}
-
-func isColoringSupported(sc kubectl.Subcommand) bool {
-	_, found := unsupported[sc]
-	return !found
-}

--- a/command/subcommand.go
+++ b/command/subcommand.go
@@ -45,4 +45,3 @@ func ResolveSubcommand(args []string, config *Config) (bool, *kubectl.Subcommand
 	// else, when the given subcommand is supported, then we colorize it
 	return subcommandFound, subcommandInfo
 }
-

--- a/config-schema.json
+++ b/config-schema.json
@@ -90,6 +90,10 @@
           "$ref": "#/$defs/color",
           "description": "default when no specific mapping is found for the command"
         },
+        "shell": {
+          "$ref": "#/$defs/themeShell",
+          "description": "colors for representing shells (e.g bash, zsh, etc)"
+        },
         "data": {
           "$ref": "#/$defs/themeData",
           "description": "colors for representing data"
@@ -125,6 +129,10 @@
         "version": {
           "$ref": "#/$defs/themeVersion",
           "description": "used in \"kubectl version\""
+        },
+        "help": {
+          "$ref": "#/$defs/themeHelp",
+          "description": "used in \"kubectl --help\""
         }
       },
       "additionalProperties": false,
@@ -287,6 +295,33 @@
       "type": "object",
       "description": "ThemeExplain holds colors for the \"kubectl explain\" output."
     },
+    "themeHelp": {
+      "properties": {
+        "header": {
+          "$ref": "#/$defs/color",
+          "description": "e.g \"Examples:\" or \"Options:\""
+        },
+        "flag": {
+          "$ref": "#/$defs/color",
+          "description": "e.g \"--kubeconfig\""
+        },
+        "flagDesc": {
+          "$ref": "#/$defs/color",
+          "description": "Flag descripion under \"Options:\" heading"
+        },
+        "url": {
+          "$ref": "#/$defs/color",
+          "description": "e.g `[https://example.com]`"
+        },
+        "text": {
+          "$ref": "#/$defs/color",
+          "description": "Fallback text color"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ThemeHelp holds colors for the \"kubectl --help\" output."
+    },
     "themeOptions": {
       "properties": {
         "flag": {
@@ -297,6 +332,29 @@
       "additionalProperties": false,
       "type": "object",
       "description": "ThemeOptions holds colors for the \"kubectl options\" output."
+    },
+    "themeShell": {
+      "properties": {
+        "comment": {
+          "$ref": "#/$defs/color",
+          "description": "used on comments, e.g `# this is a comment`"
+        },
+        "command": {
+          "$ref": "#/$defs/color",
+          "description": "used on commands, e.g `kubectl` or `echo`"
+        },
+        "arg": {
+          "$ref": "#/$defs/color",
+          "description": "used on arguments, e.g `get pods` in `kubectl get pods`"
+        },
+        "flag": {
+          "$ref": "#/$defs/color",
+          "description": "used on flags, e.g `--watch` in `kubectl get pods --watch`"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ThemeShell holds colors for when representing shell commands (bash, zsh, etc)"
     },
     "themeStatus": {
       "properties": {

--- a/config/color.go
+++ b/config/color.go
@@ -32,7 +32,20 @@ func (c Color) String() string {
 
 // Render returns the string wrapped in color codes from this color.
 func (c Color) Render(s string) string {
+	if strings.ContainsRune(s, '\033') {
+		return c.renderInject(s)
+	}
 	return color.RenderString(c.Code, s)
+}
+
+var afterResetRegex = regexp.MustCompile("\033\\[0m[^\033]")
+
+func (c Color) renderInject(s string) string {
+	updated := afterResetRegex.ReplaceAllStringFunc(s, func(orig string) string {
+		lastByte := orig[len(orig)-1]
+		return fmt.Sprintf("\033[0m\033[%sm%c", c.Code, lastByte)
+	})
+	return color.RenderString(c.Code, updated)
 }
 
 // Sprint returns the stringified args (concatenated right after each other)

--- a/config/color_test.go
+++ b/config/color_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/kubecolor/kubecolor/testutil"
@@ -106,4 +107,15 @@ func TestParseColor(t *testing.T) {
 			testutil.Equal(t, Color{Source: tc.input, Code: tc.wantCode}, got)
 		})
 	}
+}
+
+func TestRender_onColoredText(t *testing.T) {
+	highlight := MustParseColor("cyan")
+
+	s := fmt.Sprintf("prefix %s suffix", highlight.Render("highlighted"))
+	testutil.Equal(t, "prefix \033[36mhighlighted\033[0m suffix", s, "only highlight")
+
+	surrounding := MustParseColor("yellow")
+	s2 := surrounding.Render(s)
+	testutil.Equal(t, "\033[33mprefix \033[36mhighlighted\033[0m\033[33m suffix\033[0m", s2, "with surrounding color")
 }

--- a/config/theme.go
+++ b/config/theme.go
@@ -294,6 +294,7 @@ type Theme struct {
 
 	Default Color // default when no specific mapping is found for the command
 
+	Shell  ThemeShell  // colors for representing shells (e.g bash, zsh, etc)
 	Data   ThemeData   // colors for representing data
 	Status ThemeStatus // generic status coloring (e.g "Ready", "Terminating")
 	Table  ThemeTable  // used in table output, e.g "kubectl get" and parts of "kubectl describe"
@@ -304,6 +305,7 @@ type Theme struct {
 	Explain  ThemeExplain  // used in "kubectl explain"
 	Options  ThemeOptions  // used in "kubectl options"
 	Version  ThemeVersion  // used in "kubectl version"
+	Help     ThemeHelp     // used in "kubectl --help"
 }
 
 // ThemeBase contains base colors that other theme fields can default to,
@@ -321,6 +323,14 @@ type ThemeBase struct {
 	Muted     Color // general color for when things are less relevant
 
 	Key ColorSlice `defaultFromMany:"theme.base.secondary"` // general color for keys
+}
+
+// ThemeShell holds colors for when representing shell commands (bash, zsh, etc)
+type ThemeShell struct {
+	Comment Color `defaultFrom:"theme.base.muted"`     // used on comments, e.g `# this is a comment`
+	Command Color `defaultFrom:"theme.base.success"`   // used on commands, e.g `kubectl` or `echo`
+	Arg     Color `defaultFrom:"theme.base.info"`      // used on arguments, e.g `get pods` in `kubectl get pods`
+	Flag    Color `defaultFrom:"theme.base.secondary"` // used on flags, e.g `--watch` in `kubectl get pods --watch`
 }
 
 // ThemeData holds colors for when representing parsed data.
@@ -394,6 +404,15 @@ type ThemeOptions struct {
 // ThemeVersion holds colors for the "kubectl version" output.
 type ThemeVersion struct {
 	Key ColorSlice `defaultFrom:"theme.base.key"` // used on the key
+}
+
+// ThemeHelp holds colors for the "kubectl --help" output.
+type ThemeHelp struct {
+	Header   Color `defaultFrom:"theme.table.header"`   // e.g "Examples:" or "Options:"
+	Flag     Color `defaultFrom:"theme.base.secondary"` // e.g "--kubeconfig"
+	FlagDesc Color `defaultFrom:"theme.base.info"`      // Flag descripion under "Options:" heading
+	Url      Color `defaultFrom:"theme.base.secondary"` // e.g `[https://example.com]`
+	Text     Color `defaultFrom:"theme.base.info"`      // Fallback text color
 }
 
 func applyViperDefaults(theme *Theme, v *viper.Viper) {

--- a/kubectl/subcommand.go
+++ b/kubectl/subcommand.go
@@ -46,7 +46,6 @@ const (
 	Cordon       Subcommand = "cordon"
 	Cp           Subcommand = "cp"
 	Create       Subcommand = "create"
-	Ctx          Subcommand = "ctx"
 	Debug        Subcommand = "debug"
 	Delete       Subcommand = "delete"
 	Describe     Subcommand = "describe"
@@ -61,7 +60,6 @@ const (
 	Kustomize    Subcommand = "kustomize"
 	Label        Subcommand = "label"
 	Logs         Subcommand = "logs"
-	Ns           Subcommand = "ns"
 	Options      Subcommand = "options"
 	Patch        Subcommand = "patch"
 	Plugin       Subcommand = "plugin"
@@ -104,7 +102,6 @@ func InspectSubcommand(cmdArgs []string, pluginHandler PluginHandler) (Subcomman
 		Cordon,
 		Cp,
 		Create,
-		Ctx,
 		Debug,
 		Delete,
 		Describe,
@@ -119,7 +116,6 @@ func InspectSubcommand(cmdArgs []string, pluginHandler PluginHandler) (Subcomman
 		Kustomize,
 		Label,
 		Logs,
-		Ns,
 		Options,
 		Patch,
 		Plugin,
@@ -265,4 +261,30 @@ func (sci *SubcommandInfo) SupportsPager() bool {
 		return true
 	}
 	return false
+}
+
+func (sci *SubcommandInfo) SupportsColoring() bool {
+	switch sci.Subcommand {
+	case Attach,
+		Debug,
+		Edit,
+		Exec,
+		Plugin,
+		Proxy,
+		Run,
+		Wait:
+		return sci.Help
+
+	case KubectlPlugin,
+		InternalComplete:
+		return false
+
+	// oc (OpenShift CLI) specific subcommands
+	case Rsh:
+		return sci.Help
+
+	// By default, all of our commands supports coloring
+	default:
+		return true
+	}
 }

--- a/kubectl/subcommand_test.go
+++ b/kubectl/subcommand_test.go
@@ -75,7 +75,7 @@ func TestInspectSubcommandInfo(t *testing.T) {
 	}
 
 	pluginHandler := TestPluginHandler{LookupMap: map[string]string{
-		"testplugin":          "/bin/testplugin",
+		"testplugin":                    "/bin/testplugin",
 		"my_plugin-with-multiple-words": "/bin/my_plugin-with-multiple-words",
 	}}
 

--- a/printer/help.go
+++ b/printer/help.go
@@ -49,7 +49,7 @@ func (hp *HelpPrinter) Print(r io.Reader, w io.Writer) {
 			continue
 		}
 
-		if scanner.Path().HasPrefix("Options") && len(scanner.Path()) == 2 {
+		if scanner.Path().HasPrefix("Options") || scanner.Path().HasPrefix("Flags") {
 			val := string(line.Value)
 			fmt.Fprintf(w, "%s%s%s%s%s\n",
 				line.Indent,

--- a/printer/help.go
+++ b/printer/help.go
@@ -1,0 +1,124 @@
+package printer
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/kubecolor/kubecolor/config"
+	"github.com/kubecolor/kubecolor/scanner/describe"
+)
+
+// HelpPrinter is a specific printer to print kubectl explain format.
+type HelpPrinter struct {
+	Theme *config.Theme
+
+	commandBuf *bytes.Buffer
+}
+
+var urlRegex = regexp.MustCompile(`\[(https?://[a-zA-Z0-9][-a-zA-Z0-9]*\.[^\]]+)\]|(https?://[a-zA-Z0-9][-a-zA-Z0-9\.@:%_\+~#=/\?]*)`)
+
+func (hp *HelpPrinter) Print(r io.Reader, w io.Writer) {
+	scanner := describe.NewScanner(r)
+	hp.commandBuf = &bytes.Buffer{}
+
+	for scanner.Scan() {
+		line := scanner.Line()
+
+		if line.IsZero() {
+			fmt.Fprintln(w)
+			continue
+		}
+
+		if len(line.Value) == 0 &&
+			len(scanner.Path()) == 1 &&
+			strings.HasSuffix(line.String(), ":") {
+			fmt.Fprintf(w, "%s%s%s%s\n",
+				line.Indent,
+				hp.Theme.Help.Header.Render(string(line.Key)),
+				line.Spacing,
+				line.Trailing)
+			continue
+		}
+
+		if (scanner.Path().HasPrefix("Examples") || scanner.Path().HasPrefix("Usage")) &&
+			hp.printCommandLine(w, line.String()) {
+			continue
+		}
+
+		if scanner.Path().HasPrefix("Options") && len(scanner.Path()) == 2 {
+			val := string(line.Value)
+			fmt.Fprintf(w, "%s%s%s%s%s\n",
+				line.Indent,
+				hp.Theme.Help.Flag.Render(string(line.Key)),
+				line.Spacing,
+				getColorByValueType(val, hp.Theme).Render(val),
+				line.Trailing)
+			continue
+		}
+
+		text := string(slices.Concat(line.Key, line.Spacing, line.Value))
+		text = hp.colorizeUrls(text)
+		if scanner.Path().HasPrefix("Options") {
+			fmt.Fprintf(w, "%s%s%s\n",
+				line.Indent,
+				hp.Theme.Help.FlagDesc.Render(text),
+				line.Trailing)
+		} else {
+			fmt.Fprintf(w, "%s%s%s\n",
+				line.Indent,
+				hp.Theme.Help.Text.Render(text),
+				line.Trailing)
+		}
+	}
+}
+
+func (hp *HelpPrinter) printCommandLine(w io.Writer, line string) bool {
+	withoutIndent, ok := strings.CutPrefix(line, "  ")
+	if !ok {
+		return false
+	}
+	if withoutIndent == "" {
+		return false
+	}
+	if withoutIndent[0] == '#' {
+		fmt.Fprintf(w, "  %s\n", hp.Theme.Shell.Comment.Render(withoutIndent))
+		return true
+	}
+
+	hp.commandBuf.Reset()
+
+	// Don't want to use [strings.Fields], as that trims away double-spaces
+	for i, field := range strings.Split(withoutIndent, " ") {
+		if i > 0 {
+			hp.commandBuf.WriteByte(' ')
+		}
+		switch {
+		case field == "":
+			// Do nothing
+		case i == 0:
+			hp.commandBuf.WriteString(hp.Theme.Shell.Command.Render(field))
+		case field[0] == '-',
+			strings.HasPrefix(field, "[(-") && strings.HasSuffix(field, "]"):
+			hp.commandBuf.WriteString(hp.Theme.Shell.Flag.Render(field))
+		default:
+			hp.commandBuf.WriteString(hp.Theme.Shell.Arg.Render(field))
+		}
+	}
+
+	fmt.Fprint(w, "  ", hp.commandBuf.String(), "\n")
+
+	return true
+}
+
+func (hp *HelpPrinter) colorizeUrls(s string) string {
+	return urlRegex.ReplaceAllStringFunc(s, func(url string) string {
+		if url[0] == '[' {
+			return fmt.Sprintf("[%s]", hp.Theme.Help.Url.Render(url[1:len(url)-2]))
+		}
+		return hp.Theme.Help.Url.Render(url)
+	})
+}

--- a/printer/help.go
+++ b/printer/help.go
@@ -49,7 +49,7 @@ func (hp *HelpPrinter) Print(r io.Reader, w io.Writer) {
 			continue
 		}
 
-		if scanner.Path().HasPrefix("Options") || scanner.Path().HasPrefix("Flags") {
+		if (scanner.Path().HasPrefix("Options") || scanner.Path().HasPrefix("Flags")) && len(scanner.Path()) == 2 {
 			val := string(line.Value)
 			fmt.Fprintf(w, "%s%s%s%s%s\n",
 				line.Indent,

--- a/printer/kubectl_explain.go
+++ b/printer/kubectl_explain.go
@@ -12,8 +12,8 @@ import (
 
 // ExplainPrinter is a specific printer to print kubectl explain format.
 type ExplainPrinter struct {
-	Theme          *config.Theme
-	Recursive      bool
+	Theme     *config.Theme
+	Recursive bool
 }
 
 func (ep *ExplainPrinter) Print(r io.Reader, w io.Writer) {

--- a/printer/kubectl_explain.go
+++ b/printer/kubectl_explain.go
@@ -12,7 +12,6 @@ import (
 
 // ExplainPrinter is a specific printer to print kubectl explain format.
 type ExplainPrinter struct {
-	DarkBackground bool
 	Theme          *config.Theme
 	Recursive      bool
 }

--- a/printer/kubectl_output_colored_printer.go
+++ b/printer/kubectl_output_colored_printer.go
@@ -252,4 +252,3 @@ func (kp *KubectlOutputColoredPrinter) getPrinter() Printer {
 
 	return &SingleColoredPrinter{Color: kp.Theme.Default}
 }
-

--- a/printer/kubectl_output_colored_printer.go
+++ b/printer/kubectl_output_colored_printer.go
@@ -147,21 +147,28 @@ func ColorStatus(status string, theme *config.Theme) (config.Color, bool) {
 // Print reads r then write it to w, its format is based on kubectl subcommand.
 // If given subcommand is not supported by the printer, it prints data in Green.
 func (kp *KubectlOutputColoredPrinter) Print(r io.Reader, w io.Writer) {
+	printer := kp.getPrinter()
+	printer.Print(r, w)
+}
+
+func (kp *KubectlOutputColoredPrinter) getPrinter() Printer {
 	withHeader := !kp.SubcommandInfo.NoHeader
 
-	var printer Printer = &SingleColoredPrinter{Color: kp.Theme.Default}
+	if kp.SubcommandInfo.Help {
+		return &HelpPrinter{Theme: kp.Theme}
+	}
 
 	switch kp.SubcommandInfo.Subcommand {
 	case kubectl.Top, kubectl.APIResources:
-		printer = NewTablePrinter(withHeader, kp.Theme, nil)
+		return NewTablePrinter(withHeader, kp.Theme, nil)
 
 	case kubectl.APIVersions:
-		printer = NewTablePrinter(false, kp.Theme, nil) // api-versions always doesn't have header
+		return NewTablePrinter(false, kp.Theme, nil) // api-versions always doesn't have header
 
 	case kubectl.Get, kubectl.Events:
 		switch kp.SubcommandInfo.FormatOption {
 		case kubectl.None, kubectl.Wide:
-			printer = NewTablePrinter(
+			return NewTablePrinter(
 				withHeader,
 				kp.Theme,
 				func(_ int, column string) (config.Color, bool) {
@@ -197,55 +204,52 @@ func (kp *KubectlOutputColoredPrinter) Print(r io.Reader, w io.Writer) {
 				},
 			)
 		case kubectl.Json:
-			printer = &JsonPrinter{Theme: kp.Theme}
+			return &JsonPrinter{Theme: kp.Theme}
 		case kubectl.Yaml:
-			printer = &YamlPrinter{Theme: kp.Theme}
+			return &YamlPrinter{Theme: kp.Theme}
 		}
 
 	case kubectl.Describe:
-		printer = &DescribePrinter{
+		return &DescribePrinter{
 			TablePrinter: NewTablePrinter(false, kp.Theme, func(_ int, column string) (config.Color, bool) {
 				return ColorStatus(column, kp.Theme)
 			}),
 		}
 	case kubectl.Explain:
-		printer = &ExplainPrinter{
+		return &ExplainPrinter{
 			Theme:     kp.Theme,
 			Recursive: kp.Recursive,
 		}
 	case kubectl.Version:
 		switch {
 		case kp.SubcommandInfo.FormatOption == kubectl.Json:
-			printer = &JsonPrinter{Theme: kp.Theme}
+			return &JsonPrinter{Theme: kp.Theme}
 		case kp.SubcommandInfo.FormatOption == kubectl.Yaml:
-			printer = &YamlPrinter{Theme: kp.Theme}
+			return &YamlPrinter{Theme: kp.Theme}
 		case kp.SubcommandInfo.Client:
-			printer = &VersionClientPrinter{
+			return &VersionClientPrinter{
 				Theme: kp.Theme,
 			}
 		default:
-			printer = &VersionClientPrinter{
+			return &VersionClientPrinter{
 				Theme: kp.Theme,
 			}
 		}
 	case kubectl.Options:
-		printer = &OptionsPrinter{
+		return &OptionsPrinter{
 			Theme: kp.Theme,
 		}
 	case kubectl.Apply:
 		switch kp.SubcommandInfo.FormatOption {
 		case kubectl.Json:
-			printer = &JsonPrinter{Theme: kp.Theme}
+			return &JsonPrinter{Theme: kp.Theme}
 		case kubectl.Yaml:
-			printer = &YamlPrinter{Theme: kp.Theme}
+			return &YamlPrinter{Theme: kp.Theme}
 		default:
-			printer = &ApplyPrinter{Theme: kp.Theme}
+			return &ApplyPrinter{Theme: kp.Theme}
 		}
 	}
 
-	if kp.SubcommandInfo.Help {
-		printer = &SingleColoredPrinter{Color: kp.Theme.Default}
-	}
-
-	printer.Print(r, w)
+	return &SingleColoredPrinter{Color: kp.Theme.Default}
 }
+


### PR DESCRIPTION
# Description

Colorizes the help pages a bit more.

It contains a very rudamentary shell parser. It parses just enough to be able to colorize the code examples in the kubectl commands that I've tried.

### Before

![image](https://github.com/kubecolor/kubecolor/assets/2477952/82b0a20e-3390-4ae0-8fb8-f7ffaef54f1b)

### After

![image](https://github.com/kubecolor/kubecolor/assets/2477952/5627d2c1-a3f9-44c2-97b5-c10ab3ac9f91)


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## What you changed

- Added colorization of `--help` output
- Added SupportsColoring method
- Fixed where `kubectl exec --help` nor `kubectl create --help` did not get colorized
- Removed unused subcommands (ctx & ns)

## Why you think we should change it

Makes them easier to read.

## Related issue (if exists)

Closes #75
