### PR TITLE
Changed PAGER feature to opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,7 +644,7 @@ Example file (the values shows the default values):
 kubectl: kubectl # path to kubectl executable
 preset: dark # color theme preset
 objFreshThreshold: 0 # ages below this uses theme.data.durationfresh coloring
-paging: auto # whether to pipe supported subcommands to a pager ("auto" or "never")
+paging: never # whether to pipe supported subcommands to a pager ("auto" or "never")
 pager: # the command to use as pager; default uses $PAGER, less, or more
 
 # Color theme options

--- a/command/config_test.go
+++ b/command/config_test.go
@@ -21,7 +21,7 @@ func Test_ResolveConfig(t *testing.T) {
 			name: "no config",
 			args: []string{"get", "pods"},
 			expectedConf: &Config{
-				Paging:            config.PagingAuto,
+				Paging:            config.PagingDefault,
 				ForceColor:        ColorLevelUnset,
 				KubectlCmd:        "kubectl",
 				ObjFreshThreshold: time.Duration(0),
@@ -33,7 +33,7 @@ func Test_ResolveConfig(t *testing.T) {
 			name: "plain, light, force",
 			args: []string{"get", "pods", "--plain", "--light-background", "--force-colors"},
 			expectedConf: &Config{
-				Paging:            config.PagingAuto,
+				Paging:            config.PagingDefault,
 				ForceColor:        ColorLevelAuto,
 				KubectlCmd:        "kubectl",
 				ObjFreshThreshold: time.Duration(0),
@@ -46,7 +46,7 @@ func Test_ResolveConfig(t *testing.T) {
 			args: []string{"get", "pods", "--plain"},
 			env:  map[string]string{"KUBECTL_COMMAND": "kubectl.1.19"},
 			expectedConf: &Config{
-				Paging:            config.PagingAuto,
+				Paging:            config.PagingDefault,
 				ForceColor:        ColorLevelNone,
 				KubectlCmd:        "kubectl.1.19",
 				ObjFreshThreshold: time.Duration(0),
@@ -59,7 +59,7 @@ func Test_ResolveConfig(t *testing.T) {
 			args: []string{"get", "pods"},
 			env:  map[string]string{"KUBECOLOR_OBJ_FRESH": "1m"},
 			expectedConf: &Config{
-				Paging:            config.PagingAuto,
+				Paging:            config.PagingDefault,
 				ForceColor:        ColorLevelUnset,
 				KubectlCmd:        "kubectl",
 				ObjFreshThreshold: time.Minute,
@@ -72,7 +72,7 @@ func Test_ResolveConfig(t *testing.T) {
 			args: []string{"get", "pods"},
 			env:  map[string]string{"KUBECOLOR_LIGHT_BACKGROUND": "true"},
 			expectedConf: &Config{
-				Paging:          config.PagingAuto,
+				Paging:          config.PagingDefault,
 				ForceColor:      ColorLevelUnset,
 				KubectlCmd:      "kubectl",
 				Theme:           testconfig.LightTheme,
@@ -84,7 +84,7 @@ func Test_ResolveConfig(t *testing.T) {
 			args: []string{"get", "pods"},
 			env:  map[string]string{"KUBECOLOR_FORCE_COLORS": "true"},
 			expectedConf: &Config{
-				Paging:          config.PagingAuto,
+				Paging:          config.PagingDefault,
 				ForceColor:      ColorLevelAuto,
 				KubectlCmd:      "kubectl",
 				Theme:           testconfig.DarkTheme,
@@ -96,7 +96,7 @@ func Test_ResolveConfig(t *testing.T) {
 			args: []string{"get", "pods"},
 			env:  map[string]string{"KUBECOLOR_FORCE_COLORS": "truecolor"},
 			expectedConf: &Config{
-				Paging:          config.PagingAuto,
+				Paging:          config.PagingDefault,
 				ForceColor:      ColorLevelTrueColor,
 				KubectlCmd:      "kubectl",
 				Theme:           testconfig.DarkTheme,

--- a/command/runner.go
+++ b/command/runner.go
@@ -81,7 +81,7 @@ func Run(args []string, version string) error {
 	}
 
 	switch {
-		// Skip if special subcommand (e.g "kubectl exec")
+	// Skip if special subcommand (e.g "kubectl exec")
 	case !subcommandInfo.SupportsColoring(),
 		// Skip if explicitly setting --force-colors=none
 		cfg.ForceColor == ColorLevelNone,

--- a/config-schema.json
+++ b/config-schema.json
@@ -57,7 +57,7 @@
       ],
       "title": "Paging mode preference",
       "description": "Whether to pipe supported subcommands to a pager (\"auto\" or \"never\")",
-      "default": "auto"
+      "default": "never"
     },
     "preset": {
       "type": "string",

--- a/config/color_raw.go
+++ b/config/color_raw.go
@@ -7,4 +7,3 @@ type Raw string
 func (r Raw) Code() string {
 	return string(r)
 }
-

--- a/config/config.go
+++ b/config/config.go
@@ -23,7 +23,7 @@ type Config struct {
 	Preset            Preset        // Color theme preset
 	Theme             Theme         //
 	Pager             string        `jsonschema:"example=less -RF,less --RAW-CONTROL-CHARS --quit-if-one-screen,example=more"` // Command to use as pager
-	Paging            Paging        `jsonschema:"default=auto"`                                                                // Whether to enable paging: "auto" or "never"
+	Paging            Paging        `jsonschema:"default=never"`                                                               // Whether to enable paging: "auto" or "never"
 }
 
 func NewViper() *viper.Viper {

--- a/config/paging.go
+++ b/config/paging.go
@@ -16,7 +16,10 @@ const (
 )
 
 var (
-	PagingDefault = PagingAuto
+	// Due to a thorough and long lasting democratic voting process
+	// (composed by a wide represenation of one (1) person),
+	// paging was decided to be opt-in instead of opt-out. :^)
+	PagingDefault = PagingNever
 
 	AllPagingModes []Paging = []Paging{
 		PagingAuto,

--- a/kubectl/subcommand_test.go
+++ b/kubectl/subcommand_test.go
@@ -10,8 +10,8 @@ import (
 // func TestInspectSubcommandInfo(args []string) (*SubcommandInfo, bool) {
 func TestInspectSubcommandInfo(t *testing.T) {
 	tests := []struct {
-		args       string
-		expected   *SubcommandInfo
+		args     string
+		expected *SubcommandInfo
 	}{
 		{"get pods", &SubcommandInfo{Subcommand: Get}},
 		{"get pod", &SubcommandInfo{Subcommand: Get}},


### PR DESCRIPTION
# Description

Sorry @lennartack, but me and @prune998 has decided to change paging to opt-in/disabled by default instead of opt-out/enabled by default.

This also means that we don't need a release canidate for our next release.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What you changed

- Changed `paging` default from `auto` to `never`
- Ran `go fmt`
- Updated docs

## Why you think we should change it

It was too intrusive of a change to add pager support by default.

## Related issue (if exists)
