### PR TITLE
Add some subcommands to SupportsPager

### DIFF
--- a/kubectl/subcommand.go
+++ b/kubectl/subcommand.go
@@ -260,7 +260,8 @@ func (sci *SubcommandInfo) SupportsPager() bool {
 	case Describe,
 		Explain,
 		APIResources,
-		APIVersions:
+		APIVersions,
+		Config:
 		return true
 	}
 	return false

--- a/kubectl/subcommand.go
+++ b/kubectl/subcommand.go
@@ -258,7 +258,9 @@ func (sci *SubcommandInfo) SupportsPager() bool {
 	case Logs:
 		return !sci.Follow
 	case Describe,
-		Explain:
+		Explain,
+		APIResources,
+		APIVersions:
 		return true
 	}
 	return false


### PR DESCRIPTION
`api-versions`, `api-resources`, `config`

It looks like all of these are safe at the moment and a pager is useful for them