### PR TITLE
Update to Go 1.22.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.22.2 as build
+FROM docker.io/library/golang:1.22.5 as build
 
 WORKDIR /go/src/kubecolor
 COPY go.mod go.sum .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubecolor/kubecolor
 
-go 1.22.2
+go 1.22.5
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0


### PR DESCRIPTION
# Description

Updates Go from 1.22.2 to 1.22.5

## Type of change

- N/A

## What you changed

- Changed version in go.mod

## Why you think we should change it

Stay up to date with latest patches from the Go stdlib

## Related issue (if exists)
