### PR TITLE
Fixed debug log of missing config file always printing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -65,7 +65,9 @@ func LoadViper() (*viper.Viper, error) {
 
 	if err := v.ReadInConfig(); err != nil {
 		if errors.As(err, &viper.ConfigFileNotFoundError{}) || os.IsNotExist(err) {
-			fmt.Fprintf(os.Stderr, "[kubecolor] [debug] no config file found: %s\n", err)
+			if v.GetBool("debug") {
+				fmt.Fprintf(os.Stderr, "[kubecolor] [debug] no config file found: %s\n", err)
+			}
 			// continue
 		} else {
 			return nil, err


### PR DESCRIPTION
# Description

Simple change. Must've been a regression from some refactor.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (fixes an issue)

## Changes

<!-- What was changed, technically? -->

- Fixed debug log not being inside a `if v.GetBool("debug")`

## Motivation

Too much logging

