### PR TITLE
Colorize multiple statuses (e.g node `Ready,SchedulingDisabled`)

### DIFF
--- a/config/color.go
+++ b/config/color.go
@@ -65,6 +65,12 @@ func (c Color) Render(s string) string {
 var afterResetRegex = regexp.MustCompile("\033\\[0m[^\033]")
 
 func (c Color) renderInject(s string) string {
+	if strings.HasPrefix(s, "\033[") &&
+		strings.HasSuffix(s, "\033[0m") &&
+		strings.Count(s, "\033[") == 2 {
+		// If full string is colored, then doesn't matter if we add colors
+		return s
+	}
 	updated := afterResetRegex.ReplaceAllStringFunc(s, func(orig string) string {
 		lastByte := orig[len(orig)-1]
 		return fmt.Sprintf("\033[0m\033[%sm%c", c.cachedCode, lastByte)

--- a/printer/kubectl_output_colored_printer.go
+++ b/printer/kubectl_output_colored_printer.go
@@ -52,36 +52,36 @@ func (p *KubectlOutputColoredPrinter) getPrinter() Printer {
 			return NewTablePrinter(
 				withHeader,
 				p.Theme,
-				func(_ int, column string) (config.Color, bool) {
+				func(_ int, column string) string {
 					column = strings.TrimPrefix(column, "Init:")
 
 					// first try to match a status
-					col, matched := ColorStatus(column, p.Theme)
+					colored, matched := ColorStatus(column, p.Theme)
 					if matched {
-						return col, true
+						return colored
 					}
 
 					// When Readiness is "n/m" then yellow
 					if left, right, ok := stringutil.ParseRatio(column); ok {
 						switch {
 						case column == "0/0":
-							return p.Theme.Data.Ratio.Zero, true
+							return p.Theme.Data.Ratio.Zero.Render(column)
 						case left == right:
-							return p.Theme.Data.Ratio.Equal, true
+							return p.Theme.Data.Ratio.Equal.Render(column)
 						default:
-							return p.Theme.Data.Ratio.Unequal, true
+							return p.Theme.Data.Ratio.Unequal.Render(column)
 						}
 					}
 
 					// Object age when fresh then green
 					if age, ok := stringutil.ParseHumanDuration(column); ok {
 						if age < p.ObjFreshThreshold {
-							return p.Theme.Data.DurationFresh, true
+							return p.Theme.Data.DurationFresh.Render(column)
 						}
-						return p.Theme.Data.Duration, true
+						return p.Theme.Data.Duration.Render(column)
 					}
 
-					return config.Color{}, false
+					return column
 				},
 			)
 		case kubectl.Json:
@@ -92,8 +92,11 @@ func (p *KubectlOutputColoredPrinter) getPrinter() Printer {
 
 	case kubectl.Describe:
 		return &DescribePrinter{
-			TablePrinter: NewTablePrinter(false, p.Theme, func(_ int, column string) (config.Color, bool) {
-				return ColorStatus(column, p.Theme)
+			TablePrinter: NewTablePrinter(false, p.Theme, func(_ int, column string) string {
+				if colored, ok := ColorStatus(column, p.Theme); ok {
+					return colored
+				}
+				return column
 			}),
 		}
 

--- a/printer/kubectl_output_colored_printer.go
+++ b/printer/kubectl_output_colored_printer.go
@@ -53,8 +53,6 @@ func (p *KubectlOutputColoredPrinter) getPrinter() Printer {
 				withHeader,
 				p.Theme,
 				func(_ int, column string) string {
-					column = strings.TrimPrefix(column, "Init:")
-
 					// first try to match a status
 					colored, matched := ColorStatus(column, p.Theme)
 					if matched {
@@ -62,9 +60,9 @@ func (p *KubectlOutputColoredPrinter) getPrinter() Printer {
 					}
 
 					// When Readiness is "n/m" then yellow
-					if left, right, ok := stringutil.ParseRatio(column); ok {
+					if left, right, ok := stringutil.ParseRatio(strings.TrimPrefix(column, "Init:")); ok {
 						switch {
-						case column == "0/0":
+						case left == "0" && right == "0":
 							return p.Theme.Data.Ratio.Zero.Render(column)
 						case left == right:
 							return p.Theme.Data.Ratio.Equal.Render(column)

--- a/printer/util.go
+++ b/printer/util.go
@@ -68,7 +68,7 @@ func ColorDataValue(val string, theme *config.Theme) config.Color {
 }
 
 // ColorStatus returns the color that should be used for a given status text.
-func ColorStatus(status string, theme *config.Theme) (config.Color, bool) {
+func ColorStatus(status string, theme *config.Theme) (string, bool) {
 	switch status {
 	case
 		// from https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/events/event.go
@@ -127,7 +127,7 @@ func ColorStatus(status string, theme *config.Theme) (config.Color, bool) {
 		"OOMKilled",
 		// PVC status
 		"Lost":
-		return theme.Status.Error, true
+		return theme.Status.Error.Render(status), true
 	case
 		// from https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/events/event.go
 		// Container event reason list
@@ -167,7 +167,7 @@ func ColorStatus(status string, theme *config.Theme) (config.Color, bool) {
 		"Released",
 
 		"ScalingReplicaSet":
-		return theme.Status.Warning, true
+		return theme.Status.Warning.Render(status), true
 	case
 		"Running",
 		"Completed",
@@ -188,9 +188,9 @@ func ColorStatus(status string, theme *config.Theme) (config.Color, bool) {
 
 		// PVC status
 		"Bound":
-		return theme.Status.Success, true
+		return theme.Status.Success.Render(status), true
 	}
-	return config.Color{}, false
+	return status, false
 }
 
 // toSpaces returns repeated spaces whose length is n.

--- a/printer/util.go
+++ b/printer/util.go
@@ -69,7 +69,7 @@ func ColorDataValue(val string, theme *config.Theme) config.Color {
 
 // ColorStatus returns the color that should be used for a given status text.
 func ColorStatus(status string, theme *config.Theme) (string, bool) {
-	switch status {
+	switch strings.TrimPrefix(status, "Init:") {
 	case
 		// from https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/events/event.go
 		// Container event reason list

--- a/printer/util.go
+++ b/printer/util.go
@@ -69,6 +69,25 @@ func ColorDataValue(val string, theme *config.Theme) config.Color {
 
 // ColorStatus returns the color that should be used for a given status text.
 func ColorStatus(status string, theme *config.Theme) (string, bool) {
+	if strings.ContainsRune(status, ',') {
+		statuses := strings.Split(status, ",")
+		any := false
+		for i, s := range statuses {
+			if colored, ok := colorSingleStatus(s, theme); ok {
+				statuses[i] = colored
+				any = true
+			}
+		}
+		if !any {
+			return status, false
+		}
+		return strings.Join(statuses, ","), true
+	}
+
+	return colorSingleStatus(status, theme)
+}
+
+func colorSingleStatus(status string, theme *config.Theme) (string, bool) {
 	switch strings.TrimPrefix(status, "Init:") {
 	case
 		// from https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/events/event.go
@@ -115,6 +134,7 @@ func ColorStatus(status string, theme *config.Theme) (string, bool) {
 		// Node status list
 		"NotReady",
 		"NetworkUnavailable",
+		"SchedulingDisabled",
 
 		// some other status
 		"ContainerStatusUnknown",

--- a/printer/util.go
+++ b/printer/util.go
@@ -134,7 +134,6 @@ func colorSingleStatus(status string, theme *config.Theme) (string, bool) {
 		// Node status list
 		"NotReady",
 		"NetworkUnavailable",
-		"SchedulingDisabled",
 
 		// some other status
 		"ContainerStatusUnknown",
@@ -164,6 +163,7 @@ func colorSingleStatus(status string, theme *config.Theme) (string, bool) {
 		"SuccessfulAttachVolume",
 		"SuccessfulMountVolume",
 		"NodeAllocatableEnforced",
+		"SchedulingDisabled",
 		// Image manager event reason list
 		// Probe event reason list
 		"ProbeWarning",

--- a/test/corpus/table.txt
+++ b/test/corpus/table.txt
@@ -143,4 +143,4 @@ worker003   Ready,SchedulingDisabled   worker          474d   v1.28.8
 --------------------------------------------------------------------------------
 
 [1mNAME        STATUS                     ROLES           AGE    VERSION[0m
-[37mworker003[0m   [36mReady,SchedulingDisabled[0m   [37mworker[0m          [36m474d[0m   [37mv1.28.8[0m
+[37mworker003[0m   [36m[32mReady[0m[36m,[31mSchedulingDisabled[0m[0m   [37mworker[0m          [36m474d[0m   [37mv1.28.8[0m

--- a/test/corpus/table.txt
+++ b/test/corpus/table.txt
@@ -131,3 +131,16 @@ nginx-qdf9b   0/2     Init:ErrImagePull       0          2m3s
 [37mnginx-dnmv5[0m   [33m0/2[0m     [31mInit:ImagePullBackOff[0m   [36m0[0m          [37m2m3s[0m
 [37mnginx-m8pbc[0m   [33m0/2[0m     [33mInit:0/1[0m                [36m0[0m          [37m2m3s[0m
 [37mnginx-qdf9b[0m   [33m0/2[0m     [31mInit:ErrImagePull[0m       [36m0[0m          [37m2m3s[0m
+
+================================================================================
+# multiple statuses
+$ kubectl get node
+================================================================================
+
+NAME        STATUS                     ROLES           AGE    VERSION
+worker003   Ready,SchedulingDisabled   worker          474d   v1.28.8
+
+--------------------------------------------------------------------------------
+
+[1mNAME        STATUS                     ROLES           AGE    VERSION[0m
+[37mworker003[0m   [36mReady,SchedulingDisabled[0m   [37mworker[0m          [36m474d[0m   [37mv1.28.8[0m

--- a/test/corpus/table.txt
+++ b/test/corpus/table.txt
@@ -143,4 +143,4 @@ worker003   Ready,SchedulingDisabled   worker          474d   v1.28.8
 --------------------------------------------------------------------------------
 
 [1mNAME        STATUS                     ROLES           AGE    VERSION[0m
-[37mworker003[0m   [36m[32mReady[0m[36m,[31mSchedulingDisabled[0m[0m   [37mworker[0m          [36m474d[0m   [37mv1.28.8[0m
+[37mworker003[0m   [36m[32mReady[0m[36m,[33mSchedulingDisabled[0m[0m   [37mworker[0m          [36m474d[0m   [37mv1.28.8[0m


### PR DESCRIPTION
# Description

Coloring multiple statuses.

| Before | After
| ------ | -----
| ![before screenshot of test/corpus/table.txt](https://github.com/user-attachments/assets/c403c253-f27d-4f1b-aa67-f3097f848433) | ![after screenshot of test/corpus/table.txt](https://github.com/user-attachments/assets/a6912644-feba-4925-be9c-58ba0db17b92)



## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (added functionality)

## Changes

<!-- What was changed, technically? -->

- Changed code so TablePrinter's callback can modify full string
- Fixed Color.Render so it doesn't inject colors when full string is colored.
- Added coloring of `SchedulingDisabled` node status

## Motivation

<!-- Why you think we should change it? -->

Make it clearer when you have multiple statuses on a resource.

## Related issue (if exists)

<!-- remove if no related issue -->

Closes #146
