### PR TITLE
Fix linting issue in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.22.5 as build
+FROM docker.io/library/golang:1.22.5 AS build
 
 WORKDIR /go/src/kubecolor
 COPY go.mod go.sum .


### PR DESCRIPTION
# Description

Fixes the following warning:

> **The 'as' keyword should match the case of the 'from' keyword**
>
> ```
> FromAsCasing: 'as' and 'FROM' keywords' casing do not match
> More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/
> ```


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (doesn't directly affect users, e.g refactoring or CI/CD changes)

## Changes

<!-- What was changed, technically? -->

- Fixed linting issue in Dockerfile

## Motivation

Resovle the warning that's shown in PRs

