### PR TITLE
Updated config reference docs generation

### DIFF
--- a/internal/cmd/configdoc/print_yaml.go
+++ b/internal/cmd/configdoc/print_yaml.go
@@ -2,7 +2,12 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"strings"
+	"text/tabwriter"
+	"unicode"
+	"unicode/utf8"
 )
 
 type YAMLPrinter struct {
@@ -16,31 +21,34 @@ func (p *YAMLPrinter) Print() error {
 }
 
 func (p *YAMLPrinter) printCategory(category Category, path []string) error {
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
 	for _, field := range category.Fields {
 		newPath := append(path, field.Name)
 		switch field.Type {
 		case "Color":
-			p.printField(field, "color", newPath)
+			p.printField(tw, field, "color", newPath)
 		case "ColorSlice":
-			p.printField(field, "color[]", newPath)
+			p.printField(tw, field, "color[]", newPath)
 		default:
 			sub, ok := p.findCategory(field.Type)
 			if !ok {
 				return fmt.Errorf("invalid category field type: %q", field.Type)
 			}
-			fmt.Printf("%s%s:\n",
+			fmt.Fprintf(tw, "%s%s:\n",
 				strings.Repeat("  ", len(path)),
-				strings.ToLower(field.Name),
+				p.formatName(field),
 			)
+			tw.Flush()
 			if err := p.printCategory(sub, newPath); err != nil {
 				return err
 			}
 		}
 	}
+	tw.Flush()
 	return nil
 }
 
-func (p *YAMLPrinter) printField(field Field, typeString string, path []string) error {
+func (p *YAMLPrinter) printField(w io.Writer, field Field, typeString string, path []string) error {
 	fallback := p.formatFallback(field)
 	desc := strings.ReplaceAll(field.Comment, "\n", " ")
 	if fallback != "" {
@@ -53,7 +61,7 @@ func (p *YAMLPrinter) printField(field Field, typeString string, path []string) 
 		desc = " " + desc
 	}
 
-	fmt.Printf("%s%s: %s # (%s)%s\n",
+	fmt.Fprintf(w, "%s%s: %s\t# (%s)%s\n",
 		strings.Repeat("  ", len(path)-1),
 		p.formatName(field),
 		p.viper.GetString(strings.Join(path, ".")),
@@ -77,11 +85,37 @@ func (p *YAMLPrinter) formatFallback(field Field) string {
 }
 
 func (p *YAMLPrinter) formatName(field Field) string {
-	lower := strings.ToLower(field.Name)
+	lower := camelCase(field.Name)
+
 	switch lower {
 	case "true", "false", "null":
 		return fmt.Sprintf(`"%s"`, lower)
 	default:
 		return lower
 	}
+}
+
+func camelCase(s string) string {
+	if isAllUppercase(s) {
+		return strings.ToLower(s)
+	}
+	return firstLetterLowercase(s)
+}
+
+func firstLetterLowercase(s string) string {
+	var sb strings.Builder
+	sb.Grow(len(s))
+	firstRune, size := utf8.DecodeRuneInString(s)
+	sb.WriteRune(unicode.ToLower(firstRune))
+	sb.WriteString(s[size:])
+	return sb.String()
+}
+
+func isAllUppercase(s string) bool {
+	for _, r := range s {
+		if unicode.IsLower(r) {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
# Description

Changed (and bugfixed) the configdoc script.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (doesn't directly affect users, e.g refactoring or CI/CD changes)
- [x] Requires further documentation updates (on https://kubecolor.github.io/)
  - Docs needs to be regenerated (already in use in <https://github.com/kubecolor/kubecolor.github.io/pull/8>)

## Changes

<!-- What was changed, technically? -->

- Added tabwriter to YAML printer to make comments line up with each other
- Fixed some fields having wrong naming (e.g `durationfresh` -> `durationFresh`, `dryrun` -> `dryRun`). The naming implementation was copied from the JSON schema generator's naming function.

## Motivation

The tabwriter makes it more readable, and the naming fixes makes it match up with the JSON schema.

Viper (the config library) doesn't care about casing in YAML fields, so using all lowercase still _works_
