### PR TITLE
Colorize kubectl scale

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -146,6 +146,10 @@
           "$ref": "#/$defs/themeRollout",
           "description": "used in \"kubectl rollout\""
         },
+        "scale": {
+          "$ref": "#/$defs/themeScale",
+          "description": "used in \"kubectl scale\""
+        },
         "version": {
           "$ref": "#/$defs/themeVersion",
           "description": "used in \"kubectl version\""
@@ -517,6 +521,25 @@
       "additionalProperties": false,
       "type": "object",
       "description": "ThemeRollout holds colors for the \"kubectl rollout\" output."
+    },
+    "themeScale": {
+      "properties": {
+        "scaled": {
+          "$ref": "#/$defs/color",
+          "description": "used on \"deployment.apps/foo scaled\""
+        },
+        "dryRun": {
+          "$ref": "#/$defs/color",
+          "description": "used on \"(dry run)\" and \"(server dry run)\""
+        },
+        "fallback": {
+          "$ref": "#/$defs/color",
+          "description": "used when outputs unknown format"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ThemeScale holds colors for the \"kubectl scale\" output."
     },
     "themeShell": {
       "properties": {

--- a/config/theme.go
+++ b/config/theme.go
@@ -309,6 +309,7 @@ type Theme struct {
 	Options  ThemeOptions  // used in "kubectl options"
 	Patch    ThemePatch    // used in "kubectl patch"
 	Rollout  ThemeRollout  // used in "kubectl rollout"
+	Scale    ThemeScale    // used in "kubectl scale"
 	Version  ThemeVersion  // used in "kubectl version"
 	Help     ThemeHelp     // used in "kubectl --help"
 	Logs     ThemeLogs     // used in "kubectl logs"
@@ -424,6 +425,14 @@ type ThemeExpose struct {
 
 	DryRun   Color `defaultFrom:"theme.apply.dryrun"` // used on "(dry run)" and "(server dry run)"
 	Fallback Color `defaultFrom:"theme.base.primary"` // used when outputs unknown format
+}
+
+// ThemeScale holds colors for the "kubectl scale" output.
+type ThemeScale struct {
+	Scaled Color `defaultFrom:"theme.base.warning"` // used on "deployment.apps/foo scaled"
+
+	DryRun   Color `defaultFrom:"theme.apply.dryrun"` // used on "(dry run)" and "(server dry run)"
+	Fallback Color `defaultFrom:"theme.base.warning"` // used when outputs unknown format
 }
 
 // ThemeRollout holds colors for the "kubectl rollout" output.

--- a/printer/kubectl_output_colored_printer.go
+++ b/printer/kubectl_output_colored_printer.go
@@ -129,6 +129,7 @@ func (p *KubectlOutputColoredPrinter) getPrinter() Printer {
 		kubectl.Delete,
 		kubectl.Expose,
 		kubectl.Patch,
+		kubectl.Scale,
 		kubectl.Rollout:
 		switch p.SubcommandInfo.FormatOption {
 		case kubectl.JSON:
@@ -177,6 +178,14 @@ func (p *KubectlOutputColoredPrinter) getPrinter() Printer {
 				FallbackColor: p.Theme.Patch.Fallback,
 				VerbColor: map[string]config.Color{
 					"patched": p.Theme.Patch.Patched,
+				},
+			}
+		case kubectl.Scale:
+			return &VerbPrinter{
+				DryRunColor:   p.Theme.Scale.DryRun,
+				FallbackColor: p.Theme.Scale.Fallback,
+				VerbColor: map[string]config.Color{
+					"scaled": p.Theme.Scale.Scaled,
 				},
 			}
 		case kubectl.Rollout:

--- a/test/corpus/kubectl_scale.txt
+++ b/test/corpus/kubectl_scale.txt
@@ -1,0 +1,15 @@
+================================================================================
+$ kubectl scale deploy nginx --replicas 0
+================================================================================
+
+deployment.apps/nginx scaled
+deployment.apps/nginx scaled (dry run)
+deployment.apps/nginx scaled (server dry run)
+deployment.apps/nginx unknown
+
+--------------------------------------------------------------------------------
+
+deployment.apps/nginx [33mscaled[0m
+deployment.apps/nginx [33mscaled[0m [36m(dry run)[0m
+deployment.apps/nginx [33mscaled[0m [36m(server dry run)[0m
+[33mdeployment.apps/nginx unknown[0m


### PR DESCRIPTION
# Description

Colorizing `kubectl scale`

![image](https://github.com/user-attachments/assets/70f5955a-4007-43fc-a0fe-e981fd534fc2)


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (added functionality)
- [x] Requires further documentation updates (on https://kubecolor.github.io/)

## Changes

<!-- What was changed, technically? -->

- Added coloring for `kubectl scale`

## Motivation

More colors :D

