### PR TITLE
Colorize stderr logs using "kubectl logs" logic

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -624,10 +624,6 @@
     },
     "themeStderr": {
       "properties": {
-        "default": {
-          "$ref": "#/$defs/color",
-          "description": "default when no specific mapping is found for the output line"
-        },
         "error": {
           "$ref": "#/$defs/color",
           "description": "e.g when text contains \"error\""
@@ -639,6 +635,11 @@
         "noneFoundNamespace": {
           "$ref": "#/$defs/color",
           "description": "used on the namespace name of \"No resources found in my-ns namespace\""
+        },
+        "default": {
+          "$ref": "#/$defs/color",
+          "description": "default when no specific mapping is found for the output line\n\nDeprecated: This field is no longer used (since v0.4.0),\nas the stderr logs now uses the \"kubectl logs\" behavior as a fallback/default coloring.",
+          "deprecated": true
         }
       },
       "additionalProperties": false,

--- a/config/theme.go
+++ b/config/theme.go
@@ -395,7 +395,7 @@ type ThemeStderr struct {
 	//
 	// Deprecated: This field is no longer used (since v0.4.0),
 	// as the stderr logs now uses the "kubectl logs" behavior as a fallback/default coloring.
-	Default Color `jsonschema_extras:"deprecated=true"`
+	Default Color `jsonschema_extras:"deprecated=true"` // *deprecated: this field is no longer used (since v0.4.0)*
 }
 
 // ThemeApply holds colors for the "kubectl apply" output.

--- a/config/theme.go
+++ b/config/theme.go
@@ -386,11 +386,16 @@ type ThemeTable struct {
 
 // ThemeStderr holds generic colors for kubectl's stderr output.
 type ThemeStderr struct {
-	Default Color `defaultFrom:"theme.base.info"`   // default when no specific mapping is found for the output line
-	Error   Color `defaultFrom:"theme.base.danger"` // e.g when text contains "error"
+	Error Color `defaultFrom:"theme.base.danger"` // e.g when text contains "error"
 
 	NoneFound          Color `defaultFrom:"theme.data.null"`   // used on table output like "No resources found"
 	NoneFoundNamespace Color `defaultFrom:"theme.data.string"` // used on the namespace name of "No resources found in my-ns namespace"
+
+	// default when no specific mapping is found for the output line
+	//
+	// Deprecated: This field is no longer used (since v0.4.0),
+	// as the stderr logs now uses the "kubectl logs" behavior as a fallback/default coloring.
+	Default Color `jsonschema_extras:"deprecated=true"`
 }
 
 // ThemeApply holds colors for the "kubectl apply" output.

--- a/printer/stderr.go
+++ b/printer/stderr.go
@@ -20,30 +20,42 @@ var _ Printer = &StderrPrinter{}
 // Print implements [Printer.Print]
 func (p *StderrPrinter) Print(r io.Reader, w io.Writer) {
 	scanner := bufio.NewScanner(r)
+
+	logsPrinter := LogsPrinter{
+		Theme: p.Theme,
+	}
+	logsPrinterReader := strings.NewReader("")
+
 	for scanner.Scan() {
 		line := scanner.Text()
-		fmt.Fprintln(w, p.formatLine(line))
+		if s, ok := p.formatLine(line); ok {
+			fmt.Fprintln(w, s)
+			continue
+		}
+
+		logsPrinterReader.Reset(line)
+		logsPrinter.Print(logsPrinterReader, w)
 	}
 }
 
-func (p *StderrPrinter) formatLine(line string) string {
+func (p *StderrPrinter) formatLine(line string) (string, bool) {
 	if strings.HasPrefix(strings.ToLower(line), "error") {
-		return p.Theme.Stderr.Error.Render(line)
+		return p.Theme.Stderr.Error.Render(line), true
 	}
 
 	if after, ok := strings.CutPrefix(line, "No resources found"); ok {
 		if after == "" {
-			return p.Theme.Stderr.NoneFound.Render(line)
+			return p.Theme.Stderr.NoneFound.Render(line), true
 		}
 		if afterIn, ok := strings.CutPrefix(after, " in "); ok {
 			if ns, ok := strings.CutSuffix(afterIn, " namespace."); ok {
 				return p.Theme.Stderr.NoneFound.Render(fmt.Sprintf(
 					"No resources found in %s namespace.",
 					p.Theme.Stderr.NoneFoundNamespace.Render(ns),
-				))
+				)), true
 			}
 		}
 	}
 
-	return p.Theme.Stderr.Default.Render(line)
+	return "", false
 }

--- a/test/corpus/stderr.txt
+++ b/test/corpus/stderr.txt
@@ -10,7 +10,7 @@ See 'kubectl --help' for usage.
 --------------------------------------------------------------------------------
 
 [31merror: unknown flag: --foo[0m
-[37mSee 'kubectl --help' for usage.[0m
+See [93m'kubectl --help'[0m for usage.
 
 ================================================================================
 # no resources in namespace
@@ -35,3 +35,39 @@ No resources found
 --------------------------------------------------------------------------------
 
 [90;3mNo resources found[0m
+
+================================================================================
+# no such host errors
+INPUT_IS_STDERR="true"
+$ kubectl get pods
+================================================================================
+
+E0820 21:53:58.659780  149013 memcache.go:265] couldn't get current server API group list: Get "https://kubeapi.example.com:6443/api?timeout=32s": dial tcp: lookup kubeapi.example.com on 192.168.1.2:53: no such host
+E0820 21:53:58.668420  149013 memcache.go:265] couldn't get current server API group list: Get "https://kubeapi.example.com:6443/api?timeout=32s": dial tcp: lookup kubeapi.example.com on 192.168.1.2:53: no such host
+E0820 21:53:58.674577  149013 memcache.go:265] couldn't get current server API group list: Get "https://kubeapi.example.com:6443/api?timeout=32s": dial tcp: lookup kubeapi.example.com on 192.168.1.2:53: no such host
+E0820 21:53:58.682673  149013 memcache.go:265] couldn't get current server API group list: Get "https://kubeapi.example.com:6443/api?timeout=32s": dial tcp: lookup kubeapi.example.com on 192.168.1.2:53: no such host
+E0820 21:53:58.687983  149013 memcache.go:265] couldn't get current server API group list: Get "https://kubeapi.example.com:6443/api?timeout=32s": dial tcp: lookup kubeapi.example.com on 192.168.1.2:53: no such host
+Unable to connect to the server: dial tcp: lookup kubeapi.example.com on 192.168.1.2:53: no such host
+
+--------------------------------------------------------------------------------
+
+[31mE[0m[90;3m0820 21:53:58.659780[0m  149013 [90;3mmemcache.go:265[0m] couldn't get current server API group list: Get [93m"https://kubeapi.example.com:6443/api?timeout=32s"[0m: dial tcp: lookup kubeapi.example.com on 192.168.1.2:53: no such host
+[31mE[0m[90;3m0820 21:53:58.668420[0m  149013 [90;3mmemcache.go:265[0m] couldn't get current server API group list: Get [93m"https://kubeapi.example.com:6443/api?timeout=32s"[0m: dial tcp: lookup kubeapi.example.com on 192.168.1.2:53: no such host
+[31mE[0m[90;3m0820 21:53:58.674577[0m  149013 [90;3mmemcache.go:265[0m] couldn't get current server API group list: Get [93m"https://kubeapi.example.com:6443/api?timeout=32s"[0m: dial tcp: lookup kubeapi.example.com on 192.168.1.2:53: no such host
+[31mE[0m[90;3m0820 21:53:58.682673[0m  149013 [90;3mmemcache.go:265[0m] couldn't get current server API group list: Get [93m"https://kubeapi.example.com:6443/api?timeout=32s"[0m: dial tcp: lookup kubeapi.example.com on 192.168.1.2:53: no such host
+[31mE[0m[90;3m0820 21:53:58.687983[0m  149013 [90;3mmemcache.go:265[0m] couldn't get current server API group list: Get [93m"https://kubeapi.example.com:6443/api?timeout=32s"[0m: dial tcp: lookup kubeapi.example.com on 192.168.1.2:53: no such host
+Unable to connect to the server: dial tcp: lookup kubeapi.example.com on 192.168.1.2:53: no such host
+
+================================================================================
+# verbose logging
+INPUT_IS_STDERR="true"
+$ kubectl get pods -v6
+================================================================================
+
+I0820 21:55:27.250435  151288 loader.go:395] Config loaded from file:  /home/kalle/.kube/config
+I0820 21:55:27.352712  151288 round_trippers.go:553] GET https://kubeapi.example.com:6443/api/v1/namespaces/default/pods?limit=500 200 OK in 96 milliseconds
+
+--------------------------------------------------------------------------------
+
+[32mI[0m[90;3m0820 21:55:27.250435[0m  151288 [90;3mloader.go:395[0m] Config loaded from file:  /home/kalle/.kube/config
+[32mI[0m[90;3m0820 21:55:27.352712[0m  151288 [90;3mround_trippers.go:553[0m] GET [96mhttps://kubeapi.example.com:6443/api/v1/namespaces/default/pods?limit[0m=[35m500[0m [35m200[0m OK in [35m96[0m milliseconds


### PR DESCRIPTION
# Description

Changes the fallback on stderr printer from single-colored default color, to instead use the LogsPrinter.

![image](https://github.com/user-attachments/assets/32103601-e2ed-413a-9f9a-0086f8181b0e)

![image](https://github.com/user-attachments/assets/ac4e0969-e19b-4f0c-bbf8-7f37f9445a0b)


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (added functionality)
- [x] Requires further documentation updates (on https://kubecolor.github.io/)
  - deprecated a config field

## Changes

<!-- What was changed, technically? -->

- Changed StderrPrinter to make use of LogsPrinter
- Changed Config.Stderr.Default field to "deprecated"

## Motivation

Better coloring

## Related issue (if exists)

<!-- remove if no related issue -->

Closes #165
