### PR TITLE
Fixed logs parsing

### DIFF
--- a/scanner/logscan/logscan.go
+++ b/scanner/logscan/logscan.go
@@ -268,7 +268,10 @@ func (s *Scanner) pushToken(kind Kind, text string) int {
 func (s *Scanner) scanParenthases(group []byte) {
 	s.pushToken(KindParenthases, string(group[:1]))
 	inner := group[1 : len(group)-1]
-	s.scan(inner)
+	for len(inner) > 0 {
+		size := s.scan(inner)
+		inner = inner[size:]
+	}
 	s.pushToken(KindParenthases, string(group[len(group)-1:]))
 }
 

--- a/scanner/logscan/logscan.go
+++ b/scanner/logscan/logscan.go
@@ -301,7 +301,7 @@ func (s *Scanner) scanKeyValue(key, valueAndRest []byte) int {
 
 	case '{':
 		if written := s.scanJSON(valueAndRest); written > 0 {
-			return written
+			return len(key) + 1 + written
 		}
 	}
 
@@ -541,7 +541,7 @@ func readQuoted(lineBuffer []byte) []byte {
 		return nil
 	}
 	index := size
-	for {
+	for index < len(lineBuffer) {
 		nextRune, size := utf8.DecodeRune(lineBuffer[index:])
 		if nextRune == utf8.RuneError {
 			return nil
@@ -555,6 +555,7 @@ func readQuoted(lineBuffer []byte) []byte {
 			return lineBuffer[:index]
 		}
 	}
+	return nil
 }
 
 func readWord(lineBuffer []byte) []byte {

--- a/scanner/logscan/logscan_fuzz_test.go
+++ b/scanner/logscan/logscan_fuzz_test.go
@@ -1,0 +1,30 @@
+package logscan
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kubecolor/kubecolor/testutil"
+)
+
+func FuzzScanner(f *testing.F) {
+	f.Add("INFO: hello world\n")
+	f.Fuzz(func(t *testing.T, input string) {
+		// treat CR as LF
+		input = strings.ReplaceAll(input, "\r", "\n")
+		// make sure we have trailing newline
+		if !strings.HasSuffix(input, "\n") {
+			input += "\n"
+		}
+
+		scanner := NewScanner(strings.NewReader(input))
+
+		var buf bytes.Buffer
+		for scanner.Scan() {
+			buf.WriteString(scanner.Token().Text)
+		}
+
+		testutil.MustEqual(t, input, buf.String())
+	})
+}

--- a/scanner/logscan/logscan_test.go
+++ b/scanner/logscan/logscan_test.go
@@ -68,6 +68,29 @@ func TestScanner_tokens(t *testing.T) {
 			},
 		},
 		{
+			name:  "parenthases with word",
+			input: "(foo)\n",
+			want: []Token{
+				{Kind: KindParenthases, Text: "("},
+				{Kind: KindUnknown, Text: "foo"},
+				{Kind: KindParenthases, Text: ")"},
+				{Kind: KindNewline, Text: "\n"},
+			},
+		},
+		{
+			// https://github.com/kubecolor/kubecolor/issues/167
+			name:  "parenthases with words",
+			input: "(foo bar)\n",
+			want: []Token{
+				{Kind: KindParenthases, Text: "("},
+				{Kind: KindUnknown, Text: "foo"},
+				{Kind: KindUnknown, Text: " "},
+				{Kind: KindUnknown, Text: "bar"},
+				{Kind: KindParenthases, Text: ")"},
+				{Kind: KindNewline, Text: "\n"},
+			},
+		},
+		{
 			name:  "key=value",
 			input: "key=value other\n",
 			want: []Token{

--- a/scanner/logscan/testdata/fuzz/FuzzScanner/46fe09268915aa91
+++ b/scanner/logscan/testdata/fuzz/FuzzScanner/46fe09268915aa91
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("={")

--- a/scanner/logscan/testdata/fuzz/FuzzScanner/771e938e4458e983
+++ b/scanner/logscan/testdata/fuzz/FuzzScanner/771e938e4458e983
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("0")

--- a/scanner/logscan/testdata/fuzz/FuzzScanner/ff7bb51f08e94b47
+++ b/scanner/logscan/testdata/fuzz/FuzzScanner/ff7bb51f08e94b47
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("\"\\")


### PR DESCRIPTION
# Description

Fixes some log lines not being the same output as input. I tried out fuzz testing for the first time, and I can say I've quite enjoyed it.

All issues the fuzz testing found after running for a few milliseconds. After all the fixes in this PR, I let the fuzz testing run for an hour. On my 32-cores desktop while running at 100% CPU usage for a full hour it tried out 801 490 513 different inputs during, and still didn't find any more troublesome inputs:

```console
$ go test -fuzz FuzzScanner ./scanner/logscan/
fuzz: elapsed: 0s, gathering baseline coverage: 0/234 completed
fuzz: elapsed: 0s, gathering baseline coverage: 234/234 completed, now fuzzing with 32 workers
fuzz: elapsed: 3s, execs: 297125 (99036/sec), new interesting: 39 (total: 273)
fuzz: elapsed: 6s, execs: 473868 (58906/sec), new interesting: 44 (total: 278)
fuzz: elapsed: 9s, execs: 757400 (94515/sec), new interesting: 48 (total: 282)
...
fuzz: elapsed: 59m57s, execs: 798716850 (245454/sec), new interesting: 565 (total: 799)
fuzz: elapsed: 1h0m0s, execs: 799423572 (235579/sec), new interesting: 565 (total: 799)
fuzz: elapsed: 1h0m3s, execs: 800197873 (258082/sec), new interesting: 565 (total: 799)
fuzz: elapsed: 1h0m6s, execs: 800953535 (251882/sec), new interesting: 565 (total: 799)
^Cfuzz: elapsed: 1h0m9s, execs: 801490513 (201869/sec), new interesting: 565 (total: 799)
PASS
ok  	github.com/kubecolor/kubecolor/scanner/logscan	3608.782s
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (fixes an issue)

## Changes

<!-- What was changed, technically? -->


- Fixed log parsing parentheses with multiple words (e.g `(foo bar)` -> `(foo)`)
- Fixed log parsing unclosed quotes (e.g `"foo` -> panic)
- Fixed log parsing unclosed parentheses in key value (e.g `key={` -> `key={{`)

## Motivation

Fixes issue where `kubectl logs` and `kubecolor logs` would show different output.

## Related issue (if exists)

<!-- remove if no related issue -->

Closes #167 
