### PR TITLE
allow negative tz offsets in time regex

### DIFF
--- a/scanner/logscan/logscan.go
+++ b/scanner/logscan/logscan.go
@@ -22,7 +22,7 @@ var klogLevelAndDateRegex = regexp.MustCompile(`^([IWEF])(\d{4} \d\d:\d\d:\d\d\.
 //	2024-08-03 20:04:28.614 GMT
 //	03 Aug 2024 20:04:28.614 GMT
 //	Aug/03/2024:20:04:28.614 +02:00
-var dateRegex = regexp.MustCompile(`^\d{4}-\d\d-\d\dT\d\d:\d\d(:\d\d(\.\d+)?)?(Z|\+\d\d:\d\d|\+\d{4})?\b|^(\d{4}-\d\d-\d\d|\d\d ([a-zA-Z][a-z]+) \d{4}|\d\d/([a-zA-Z][a-z]+)/\d{4})[ :]\d\d:\d\d(:\d\d(\.\d+)?)?( ?(GMT|UTC|\+\d\d:\d\d|\+\d\d\d\d))?\b`)
+var dateRegex = regexp.MustCompile(`^\d{4}-\d\d-\d\dT\d\d:\d\d(:\d\d(\.\d+)?)?(Z|[+-]\d\d:\d\d|[+-]\d{4})?\b|^(\d{4}-\d\d-\d\d|\d\d ([a-zA-Z][a-z]+) \d{4}|\d\d/([a-zA-Z][a-z]+)/\d{4})[ :]\d\d:\d\d(:\d\d(\.\d+)?)?( ?(GMT|UTC|[+-]\d\d:\d\d|[+-]\d\d\d\d))?\b`)
 
 // guidRegex is for matching on GUIDs and UUIDs. E.g:
 //

--- a/scanner/logscan/logscan_test.go
+++ b/scanner/logscan/logscan_test.go
@@ -151,6 +151,14 @@ func TestScanner_tokens(t *testing.T) {
 			},
 		},
 		{
+			name:  "date iso8601 negative timezone",
+			input: "2024-08-03T12:38:44.049832713-0500\n",
+			want: []Token{
+				{Kind: KindDate, Text: "2024-08-03T12:38:44.049832713-0500"},
+				{Kind: KindNewline, Text: "\n"},
+			},
+		},
+		{
 			name:  "guid dashes",
 			input: "70d5707e-b07b-41c3-9411-cad84c6db764\n",
 			want: []Token{


### PR DESCRIPTION
# Description

* since `+02:00` was highlighted as time, `-05:00` should also be
  highlighted as part of a timestamp

## Type of change

- [x] New feature (added functionality)

## Changes

- Changed `dateRegex` to also accept negative TZ offsets
  - Add test case for `-0500`

## Motivation

We highlight `+02:00` but not `-0500`
