### PR TITLE
Fixed govulncheck workflow

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -27,8 +27,11 @@ jobs:
         id: govulncheck
         run: |
           echo "govulncheck<<GOVULNCHECK_OUTPUT" >> $GITHUB_OUTPUT
+          set +e # don't exit on error
           govulncheck ./... 2>&1 | tee --append $GITHUB_OUTPUT
+          exit_status=$?
           echo "GOVULNCHECK_OUTPUT" >> $GITHUB_OUTPUT
+          exit $exit_status
         shell: bash
 
       - name: Create GitHub issue


### PR DESCRIPTION
# Description

Fixes so the generated issues contain the govulncheck output

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (fixes an issue)

## Changes

<!-- What was changed, technically? -->

- Fixed `GOVULNCHECK_OUTPUT` not being written when the govulncheck command fails

## Motivation

Exhibit A: https://github.com/kubecolor/kubecolor/issues/175
