### PR TITLE
Update to Go 1.22.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.22.5 AS build
+FROM docker.io/library/golang:1.22.7 AS build
 
 WORKDIR /go/src/kubecolor
 COPY go.mod go.sum .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubecolor/kubecolor
 
-go 1.22.5
+go 1.22.7
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0


### PR DESCRIPTION
# Description

Updates Go to latest v1.22 release to resolve vulnerabilities:

- Stack exhaustion in Parse in go/build/constraint: https://pkg.go.dev/vuln/GO-2024-3107
- Stack exhaustion in all Parse functions in go/parser: https://pkg.go.dev/vuln/GO-2024-3105

These vulnerabilities only affect our internal generator commands (`./internal/cmd/configschema` & `./internal/cmd/configdoc`), so it's not super urgent.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (doesn't directly affect users, e.g refactoring or CI/CD changes)

## Changes

<!-- What was changed, technically? -->

- Changed version in go.mod
- Changed version in Dockerfile

## Motivation

Stay up to date and do not ship vulnerabilities

## Related issue (if exists)

<!-- remove if no related issue -->

Closes #175
