### PR TITLE
Fixed 'kubectl version -o yaml' indentation

### DIFF
--- a/printer/kubectl_version.go
+++ b/printer/kubectl_version.go
@@ -90,10 +90,12 @@ func (vp *VersionYAMLInjectorPrinter) Print(r io.Reader, w io.Writer) {
 		return
 	}
 	output["kubecolorVersion"] = vp.KubecolorVersion
-	result, err := yaml.Marshal(output)
-	if err != nil {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(output); err != nil {
 		w.Write(b)
 		return
 	}
-	vp.YamlPrinter.Print(bytes.NewReader(result), w)
+	vp.YamlPrinter.Print(&buf, w)
 }


### PR DESCRIPTION
# Description

Fixes the indentation of `kubectl version -o yaml`. The original kubectl output uses 2 spaces for indentation, but in v0.4.0 we accidentally changed it to 4 spaces when doing the "kubecolor version injection".

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (fixes an issue)

## Changes

<!-- What was changed, technically? -->

- Fixed YAML indentation of `kubectl version -o yaml` of being 4 instead of 2

## Motivation

Bug.

This wouldn't appear in any scripts as kubecolor is only doing this when it can also apply colors, so any scripts that do weird stuff like "read the N'th line and then skip 2 spaces" didn't get affected anyways. This is just a visual thing

## Related issue (if exists)

<!-- remove if no related issue -->

no issue
