### PR TITLE
Feat: Adding color-rendering for kubectl diff

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -208,10 +208,6 @@
     },
     "themeBase": {
       "properties": {
-        "added": {
-          "$ref": "#/$defs/color",
-          "description": "general color for when things are added in"
-        },
         "danger": {
           "$ref": "#/$defs/color",
           "description": "general color for when things are bad"
@@ -228,10 +224,6 @@
           "$ref": "#/$defs/color",
           "description": "general color for when things are focus"
         },
-        "removed": {
-          "$ref": "#/$defs/color",
-          "description": "general color for when things are removed"
-        },
         "secondary": {
           "$ref": "#/$defs/color",
           "description": "general color for when things are secondary focus"
@@ -239,10 +231,6 @@
         "success": {
           "$ref": "#/$defs/color",
           "description": "general color for when things are good"
-        },
-        "unchanged": {
-          "$ref": "#/$defs/color",
-          "description": "general color for when things are unchanged"
         },
         "warning": {
           "$ref": "#/$defs/color",

--- a/config-schema.json
+++ b/config-schema.json
@@ -169,6 +169,10 @@
         "logs": {
           "$ref": "#/$defs/themeLogs",
           "description": "used in \"kubectl logs\""
+        },
+        "diff": {
+          "$ref": "#/$defs/themeDiff",
+          "description": "used in \"kubectl diff\""
         }
       },
       "additionalProperties": false,
@@ -204,13 +208,29 @@
     },
     "themeBase": {
       "properties": {
+        "added": {
+          "$ref": "#/$defs/color",
+          "description": "general color for when things are added in"
+        },
+        "danger": {
+          "$ref": "#/$defs/color",
+          "description": "general color for when things are bad"
+        },
         "info": {
           "$ref": "#/$defs/color",
           "description": "general color for when things are informational"
         },
+        "muted": {
+          "$ref": "#/$defs/color",
+          "description": "general color for when things are less relevant"
+        },
         "primary": {
           "$ref": "#/$defs/color",
           "description": "general color for when things are focus"
+        },
+        "removed": {
+          "$ref": "#/$defs/color",
+          "description": "general color for when things are removed"
         },
         "secondary": {
           "$ref": "#/$defs/color",
@@ -220,17 +240,13 @@
           "$ref": "#/$defs/color",
           "description": "general color for when things are good"
         },
+        "unchanged": {
+          "$ref": "#/$defs/color",
+          "description": "general color for when things are unchanged"
+        },
         "warning": {
           "$ref": "#/$defs/color",
           "description": "general color for when things are wrong"
-        },
-        "danger": {
-          "$ref": "#/$defs/color",
-          "description": "general color for when things are bad"
-        },
-        "muted": {
-          "$ref": "#/$defs/color",
-          "description": "general color for when things are less relevant"
         },
         "key": {
           "$ref": "#/$defs/colorSlice",
@@ -353,6 +369,25 @@
       "additionalProperties": false,
       "type": "object",
       "description": "ThemeApply holds colors for the \"kubectl apply\" output."
+    },
+    "themeDiff": {
+      "properties": {
+        "added": {
+          "$ref": "#/$defs/color",
+          "description": "used on added lines"
+        },
+        "removed": {
+          "$ref": "#/$defs/color",
+          "description": "used on removed lines"
+        },
+        "unchanged": {
+          "$ref": "#/$defs/color",
+          "description": "used on unchanged lines"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ThemeDiff holds colors for the \"kubectl diff\" output."
     },
     "themeDrain": {
       "properties": {

--- a/config/theme.go
+++ b/config/theme.go
@@ -25,6 +25,9 @@ func NewBaseTheme(preset Preset) *Theme {
 				Warning:   color.MustParse("yellow"),
 				Danger:    color.MustParse("red"),
 				Muted:     color.MustParse("gray:italic"),
+				Added:     color.MustParse("green"),
+				Removed:   color.MustParse("red"),
+				Unchanged: color.MustParse("gray"),
 			},
 			Table: ThemeTable{
 				Header: color.MustParse("bold"),
@@ -46,6 +49,9 @@ func NewBaseTheme(preset Preset) *Theme {
 				Warning:   color.MustParse("yellow"),
 				Danger:    color.MustParse("red"),
 				Muted:     color.MustParse("gray:italic"),
+				Added:     color.MustParse("green"),
+				Removed:   color.MustParse("red"),
+				Unchanged: color.MustParse("gray"),
 			},
 			Table: ThemeTable{
 				Header: color.MustParse("bold"),
@@ -68,6 +74,9 @@ func NewBaseTheme(preset Preset) *Theme {
 				Warning:   color.MustParse("#feb927:italic"),      // yellow
 				Danger:    color.MustParse("fg=white:bg=#c2270a"), // red background
 				Muted:     color.MustParse("#2ee5ae:italic"),      // white-ish
+				Added:     color.MustParse("#6afd6a"),             // green
+				Removed:   color.MustParse("#c2270a"),             // red
+				Unchanged: color.MustParse("#2ee5ae"),             // white-ish
 			},
 			Data: ThemeData{
 				String: color.MustParse("#2aabee"),
@@ -90,6 +99,9 @@ func NewBaseTheme(preset Preset) *Theme {
 				Warning:   color.MustParse("#feb927:italic"),
 				Danger:    color.MustParse("fg=black:bg=#c2270a"),
 				Muted:     color.MustParse("#2ee5ae:italic"),
+				Added:     color.MustParse("#6afd6a"),
+				Removed:   color.MustParse("#c2270a"),
+				Unchanged: color.MustParse("#2ee5ae"),
 			},
 			Data: ThemeData{
 				String: color.MustParse("#2aabee"),
@@ -113,6 +125,9 @@ func NewBaseTheme(preset Preset) *Theme {
 				Warning:   color.MustParse("#feb927:italic"),
 				Danger:    color.MustParse("fg=white:bg=#c2270a"),
 				Muted:     color.MustParse("#2ee5ae"),
+				Added:     color.MustParse("#6afd6a"),
+				Removed:   color.MustParse("#c2270a"),
+				Unchanged: color.MustParse("#2ee5ae"),
 			},
 			Data: ThemeData{
 				String: color.MustParse("#2aabee"),
@@ -135,6 +150,9 @@ func NewBaseTheme(preset Preset) *Theme {
 				Warning:   color.MustParse("#feb927:italic"),
 				Danger:    color.MustParse("fg=black:bg=#c2270a"),
 				Muted:     color.MustParse("#2ee5ae:italic"),
+				Added:     color.MustParse("#6afd6a"),
+				Removed:   color.MustParse("#c2270a"),
+				Unchanged: color.MustParse("#2ee5ae"),
 			},
 			Data: ThemeData{
 				String: color.MustParse("#2aabee"),
@@ -158,6 +176,9 @@ func NewBaseTheme(preset Preset) *Theme {
 				Warning:   color.MustParse("#feb927:italic"),
 				Danger:    color.MustParse("fg=white:bg=#c2270a"),
 				Muted:     color.MustParse("#2ee5ae"),
+				Added:     color.MustParse("#6afd6a"),
+				Removed:   color.MustParse("#c2270a"),
+				Unchanged: color.MustParse("#2ee5ae"),
 			},
 			Data: ThemeData{
 				String: color.MustParse("#2aabee"),
@@ -178,8 +199,11 @@ func NewBaseTheme(preset Preset) *Theme {
 				Secondary: color.MustParse("#2aabee"),
 				Success:   color.MustParse("#6afd6a:bold"),
 				Warning:   color.MustParse("#feb927:italic"),
-				Danger:    color.MustParse("fg=black:bg=#c2270a"),
+				Danger:    color.MustParse("fg=black:bg=green"),
 				Muted:     color.MustParse("#2ee5ae:italic"),
+				Added:     color.MustParse("#6afd6a"),
+				Removed:   color.MustParse("#c2270a"),
+				Unchanged: color.MustParse("#2ee5ae"),
 			},
 			Data: ThemeData{
 				String: color.MustParse("#2aabee"),
@@ -203,6 +227,9 @@ func NewBaseTheme(preset Preset) *Theme {
 				Warning:   color.MustParse("yellow"),
 				Danger:    color.MustParse("red"),
 				Muted:     color.MustParse("yellow"),
+				Added:     color.MustParse("green"),
+				Removed:   color.MustParse("red"),
+				Unchanged: color.MustParse("white"),
 			},
 			Options: ThemeOptions{
 				Flag: color.MustParse("yellow"),
@@ -221,6 +248,9 @@ func NewBaseTheme(preset Preset) *Theme {
 				Warning:   color.MustParse("yellow"),
 				Danger:    color.MustParse("red"),
 				Muted:     color.MustParse("yellow"),
+				Added:     color.MustParse("green"),
+				Removed:   color.MustParse("red"),
+				Unchanged: color.MustParse("black"),
 			},
 			Options: ThemeOptions{
 				Flag: color.MustParse("yellow"),
@@ -240,6 +270,9 @@ func NewBaseTheme(preset Preset) *Theme {
 				Warning:   color.MustParse("yellow"),
 				Danger:    color.MustParse("red"),
 				Muted:     color.MustParse("yellow"),
+				Added:     color.MustParse("green"),
+				Removed:   color.MustParse("red"),
+				Unchanged: color.MustParse("white"),
 			},
 			Data: ThemeData{
 				String: color.MustParse("cyan"),
@@ -267,6 +300,9 @@ func NewBaseTheme(preset Preset) *Theme {
 				Warning:   color.MustParse("yellow"),
 				Danger:    color.MustParse("red"),
 				Muted:     color.MustParse("yellow"),
+				Added:     color.MustParse("green"),
+				Removed:   color.MustParse("red"),
+				Unchanged: color.MustParse("black"),
 			},
 			Data: ThemeData{
 				String: color.MustParse("blue"),
@@ -330,13 +366,16 @@ func (t *Theme) ComputeCache() {
 // These fields should never be referenced in the printers.
 // Instead, they should use the more specific fields, such as [ThemeApply.Created]
 type ThemeBase struct {
+	Added     color.Color // general color for when things are added in
+	Danger    color.Color // general color for when things are bad
 	Info      color.Color // general color for when things are informational
+	Muted     color.Color // general color for when things are less relevant
 	Primary   color.Color // general color for when things are focus
+	Removed   color.Color // general color for when things are removed
 	Secondary color.Color // general color for when things are secondary focus
 	Success   color.Color // general color for when things are good
+	Unchanged color.Color // general color for when things are unchanged
 	Warning   color.Color // general color for when things are wrong
-	Danger    color.Color // general color for when things are bad
-	Muted     color.Color // general color for when things are less relevant
 
 	Key color.Slice `defaultFromMany:"theme.base.secondary"` // general color for keys
 }
@@ -493,9 +532,9 @@ type ThemeExplain struct {
 
 // ThemeDiff holds colors for the "kubectl diff" output.
 type ThemeDiff struct {
-	Added     color.Color `defaultFrom:"theme.base.success"` // used on added lines
-	Removed   color.Color `defaultFrom:"theme.base.danger"`  // used on removed lines
-	Unchanged color.Color `defaultFrom:"theme.base.muted"`   // used on unchanged lines
+	Added     color.Color `defaultFrom:"theme.base.added"`     // used on added lines
+	Removed   color.Color `defaultFrom:"theme.base.removed"`   // used on removed lines
+	Unchanged color.Color `defaultFrom:"theme.base.unchanged"` // used on unchanged lines
 }
 
 // ThemeOptions holds colors for the "kubectl options" output.

--- a/config/theme.go
+++ b/config/theme.go
@@ -316,6 +316,7 @@ type Theme struct {
 	Version  ThemeVersion  // used in "kubectl version"
 	Help     ThemeHelp     // used in "kubectl --help"
 	Logs     ThemeLogs     // used in "kubectl logs"
+	Diff     ThemeDiff     // used in "kubectl diff"
 }
 
 func (t *Theme) ComputeCache() {
@@ -488,6 +489,13 @@ type ThemeDrain struct {
 type ThemeExplain struct {
 	Key      color.Slice `defaultFrom:"theme.base.key"`    // used on keys. The multiple colors are cycled based on indentation.
 	Required color.Color `defaultFrom:"theme.base.danger"` // used on the trailing "-required-" string
+}
+
+// ThemeDiff holds colors for the "kubectl diff" output.
+type ThemeDiff struct {
+	Added     color.Color `defaultFrom:"theme.base.success"` // used on added lines
+	Removed   color.Color `defaultFrom:"theme.base.danger"`  // used on removed lines
+	Unchanged color.Color `defaultFrom:"theme.base.muted"`   // used on unchanged lines
 }
 
 // ThemeOptions holds colors for the "kubectl options" output.

--- a/config/theme.go
+++ b/config/theme.go
@@ -199,7 +199,7 @@ func NewBaseTheme(preset Preset) *Theme {
 				Secondary: color.MustParse("#2aabee"),
 				Success:   color.MustParse("#6afd6a:bold"),
 				Warning:   color.MustParse("#feb927:italic"),
-				Danger:    color.MustParse("fg=black:bg=green"),
+				Danger:    color.MustParse("fg=black:bg=#c2270a"),
 				Muted:     color.MustParse("#2ee5ae:italic"),
 				Added:     color.MustParse("#6afd6a"),
 				Removed:   color.MustParse("#c2270a"),
@@ -229,7 +229,7 @@ func NewBaseTheme(preset Preset) *Theme {
 				Muted:     color.MustParse("yellow"),
 				Added:     color.MustParse("green"),
 				Removed:   color.MustParse("red"),
-				Unchanged: color.MustParse("white"),
+				Unchanged: color.MustParse("yellow"),
 			},
 			Options: ThemeOptions{
 				Flag: color.MustParse("yellow"),
@@ -250,7 +250,7 @@ func NewBaseTheme(preset Preset) *Theme {
 				Muted:     color.MustParse("yellow"),
 				Added:     color.MustParse("green"),
 				Removed:   color.MustParse("red"),
-				Unchanged: color.MustParse("black"),
+				Unchanged: color.MustParse("yellow"),
 			},
 			Options: ThemeOptions{
 				Flag: color.MustParse("yellow"),
@@ -272,7 +272,7 @@ func NewBaseTheme(preset Preset) *Theme {
 				Muted:     color.MustParse("yellow"),
 				Added:     color.MustParse("green"),
 				Removed:   color.MustParse("red"),
-				Unchanged: color.MustParse("white"),
+				Unchanged: color.MustParse("yellow"),
 			},
 			Data: ThemeData{
 				String: color.MustParse("cyan"),
@@ -302,7 +302,7 @@ func NewBaseTheme(preset Preset) *Theme {
 				Muted:     color.MustParse("yellow"),
 				Added:     color.MustParse("green"),
 				Removed:   color.MustParse("red"),
-				Unchanged: color.MustParse("black"),
+				Unchanged: color.MustParse("yellow"),
 			},
 			Data: ThemeData{
 				String: color.MustParse("blue"),

--- a/config/theme.go
+++ b/config/theme.go
@@ -25,9 +25,6 @@ func NewBaseTheme(preset Preset) *Theme {
 				Warning:   color.MustParse("yellow"),
 				Danger:    color.MustParse("red"),
 				Muted:     color.MustParse("gray:italic"),
-				Added:     color.MustParse("green"),
-				Removed:   color.MustParse("red"),
-				Unchanged: color.MustParse("gray"),
 			},
 			Table: ThemeTable{
 				Header: color.MustParse("bold"),
@@ -49,9 +46,6 @@ func NewBaseTheme(preset Preset) *Theme {
 				Warning:   color.MustParse("yellow"),
 				Danger:    color.MustParse("red"),
 				Muted:     color.MustParse("gray:italic"),
-				Added:     color.MustParse("green"),
-				Removed:   color.MustParse("red"),
-				Unchanged: color.MustParse("gray"),
 			},
 			Table: ThemeTable{
 				Header: color.MustParse("bold"),
@@ -74,9 +68,6 @@ func NewBaseTheme(preset Preset) *Theme {
 				Warning:   color.MustParse("#feb927:italic"),      // yellow
 				Danger:    color.MustParse("fg=white:bg=#c2270a"), // red background
 				Muted:     color.MustParse("#2ee5ae:italic"),      // white-ish
-				Added:     color.MustParse("#6afd6a"),             // green
-				Removed:   color.MustParse("#c2270a"),             // red
-				Unchanged: color.MustParse("#2ee5ae"),             // white-ish
 			},
 			Data: ThemeData{
 				String: color.MustParse("#2aabee"),
@@ -99,9 +90,6 @@ func NewBaseTheme(preset Preset) *Theme {
 				Warning:   color.MustParse("#feb927:italic"),
 				Danger:    color.MustParse("fg=black:bg=#c2270a"),
 				Muted:     color.MustParse("#2ee5ae:italic"),
-				Added:     color.MustParse("#6afd6a"),
-				Removed:   color.MustParse("#c2270a"),
-				Unchanged: color.MustParse("#2ee5ae"),
 			},
 			Data: ThemeData{
 				String: color.MustParse("#2aabee"),
@@ -125,9 +113,6 @@ func NewBaseTheme(preset Preset) *Theme {
 				Warning:   color.MustParse("#feb927:italic"),
 				Danger:    color.MustParse("fg=white:bg=#c2270a"),
 				Muted:     color.MustParse("#2ee5ae"),
-				Added:     color.MustParse("#6afd6a"),
-				Removed:   color.MustParse("#c2270a"),
-				Unchanged: color.MustParse("#2ee5ae"),
 			},
 			Data: ThemeData{
 				String: color.MustParse("#2aabee"),
@@ -150,9 +135,6 @@ func NewBaseTheme(preset Preset) *Theme {
 				Warning:   color.MustParse("#feb927:italic"),
 				Danger:    color.MustParse("fg=black:bg=#c2270a"),
 				Muted:     color.MustParse("#2ee5ae:italic"),
-				Added:     color.MustParse("#6afd6a"),
-				Removed:   color.MustParse("#c2270a"),
-				Unchanged: color.MustParse("#2ee5ae"),
 			},
 			Data: ThemeData{
 				String: color.MustParse("#2aabee"),
@@ -176,9 +158,6 @@ func NewBaseTheme(preset Preset) *Theme {
 				Warning:   color.MustParse("#feb927:italic"),
 				Danger:    color.MustParse("fg=white:bg=#c2270a"),
 				Muted:     color.MustParse("#2ee5ae"),
-				Added:     color.MustParse("#6afd6a"),
-				Removed:   color.MustParse("#c2270a"),
-				Unchanged: color.MustParse("#2ee5ae"),
 			},
 			Data: ThemeData{
 				String: color.MustParse("#2aabee"),
@@ -201,9 +180,6 @@ func NewBaseTheme(preset Preset) *Theme {
 				Warning:   color.MustParse("#feb927:italic"),
 				Danger:    color.MustParse("fg=black:bg=#c2270a"),
 				Muted:     color.MustParse("#2ee5ae:italic"),
-				Added:     color.MustParse("#6afd6a"),
-				Removed:   color.MustParse("#c2270a"),
-				Unchanged: color.MustParse("#2ee5ae"),
 			},
 			Data: ThemeData{
 				String: color.MustParse("#2aabee"),
@@ -227,9 +203,6 @@ func NewBaseTheme(preset Preset) *Theme {
 				Warning:   color.MustParse("yellow"),
 				Danger:    color.MustParse("red"),
 				Muted:     color.MustParse("yellow"),
-				Added:     color.MustParse("green"),
-				Removed:   color.MustParse("red"),
-				Unchanged: color.MustParse("yellow"),
 			},
 			Options: ThemeOptions{
 				Flag: color.MustParse("yellow"),
@@ -248,9 +221,6 @@ func NewBaseTheme(preset Preset) *Theme {
 				Warning:   color.MustParse("yellow"),
 				Danger:    color.MustParse("red"),
 				Muted:     color.MustParse("yellow"),
-				Added:     color.MustParse("green"),
-				Removed:   color.MustParse("red"),
-				Unchanged: color.MustParse("yellow"),
 			},
 			Options: ThemeOptions{
 				Flag: color.MustParse("yellow"),
@@ -270,9 +240,6 @@ func NewBaseTheme(preset Preset) *Theme {
 				Warning:   color.MustParse("yellow"),
 				Danger:    color.MustParse("red"),
 				Muted:     color.MustParse("yellow"),
-				Added:     color.MustParse("green"),
-				Removed:   color.MustParse("red"),
-				Unchanged: color.MustParse("yellow"),
 			},
 			Data: ThemeData{
 				String: color.MustParse("cyan"),
@@ -300,9 +267,6 @@ func NewBaseTheme(preset Preset) *Theme {
 				Warning:   color.MustParse("yellow"),
 				Danger:    color.MustParse("red"),
 				Muted:     color.MustParse("yellow"),
-				Added:     color.MustParse("green"),
-				Removed:   color.MustParse("red"),
-				Unchanged: color.MustParse("yellow"),
 			},
 			Data: ThemeData{
 				String: color.MustParse("blue"),
@@ -366,15 +330,12 @@ func (t *Theme) ComputeCache() {
 // These fields should never be referenced in the printers.
 // Instead, they should use the more specific fields, such as [ThemeApply.Created]
 type ThemeBase struct {
-	Added     color.Color // general color for when things are added in
 	Danger    color.Color // general color for when things are bad
 	Info      color.Color // general color for when things are informational
 	Muted     color.Color // general color for when things are less relevant
 	Primary   color.Color // general color for when things are focus
-	Removed   color.Color // general color for when things are removed
 	Secondary color.Color // general color for when things are secondary focus
 	Success   color.Color // general color for when things are good
-	Unchanged color.Color // general color for when things are unchanged
 	Warning   color.Color // general color for when things are wrong
 
 	Key color.Slice `defaultFromMany:"theme.base.secondary"` // general color for keys
@@ -532,9 +493,9 @@ type ThemeExplain struct {
 
 // ThemeDiff holds colors for the "kubectl diff" output.
 type ThemeDiff struct {
-	Added     color.Color `defaultFrom:"theme.base.added"`     // used on added lines
-	Removed   color.Color `defaultFrom:"theme.base.removed"`   // used on removed lines
-	Unchanged color.Color `defaultFrom:"theme.base.unchanged"` // used on unchanged lines
+	Added     color.Color `defaultFrom:"theme.base.success"` // used on added lines
+	Removed   color.Color `defaultFrom:"theme.base.danger"`  // used on removed lines
+	Unchanged color.Color `defaultFrom:"theme.base.muted"`   // used on unchanged lines
 }
 
 // ThemeOptions holds colors for the "kubectl options" output.

--- a/internal/stringutil/stringutil.go
+++ b/internal/stringutil/stringutil.go
@@ -37,6 +37,15 @@ func IsDigit(r rune) bool {
 	return r >= '0' && r <= '9'
 }
 
+func IsAllSameRune(s string, r rune) bool {
+	for _, elem := range s {
+		if elem != r {
+			return false
+		}
+	}
+	return true
+}
+
 func CutNumber(s string) (num, after string, found bool) {
 	if s == "" {
 		return "", s, false

--- a/internal/testcorpus/scanner.go
+++ b/internal/testcorpus/scanner.go
@@ -1,168 +1,168 @@
 package testcorpus
 
 import (
-  "bufio"
-  "errors"
-  "fmt"
-  "io"
-  "regexp"
-  "slices"
-  "strings"
-  "unicode/utf8"
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"slices"
+	"strings"
+	"unicode/utf8"
 )
 
 func NewTestScanner(reader io.Reader) *TestScanner {
-  return &TestScanner{
-    scanner: bufio.NewScanner(reader),
-    first:   true,
-  }
+	return &TestScanner{
+		scanner: bufio.NewScanner(reader),
+		first:   true,
+	}
 }
 
 type TestScanner struct {
-  scanner *bufio.Scanner
+	scanner *bufio.Scanner
 
-  test  Test
-  err   error
-  done  bool
-  first bool
+	test  Test
+	err   error
+	done  bool
+	first bool
 }
 
 func (s *TestScanner) Scan() bool {
-  s.err = s.scanErr()
-  return s.err == nil && !s.done
+	s.err = s.scanErr()
+	return s.err == nil && !s.done
 }
 
 func (s *TestScanner) Test() Test {
-  return s.test
+	return s.test
 }
 
 func (s *TestScanner) Err() error {
-  return s.err
+	return s.err
 }
 
 func (s *TestScanner) scanErr() error {
-  if s.first {
-    s.first = false
-    if _, err := scanLinesUntilCharLine(s.scanner, "="); errors.Is(err, io.ErrUnexpectedEOF) {
-      // no tests found
-      s.done = true
-      return nil
-    } else if err != nil {
-      return err
-    }
-  }
+	if s.first {
+		s.first = false
+		if _, err := scanLinesUntilCharLine(s.scanner, "="); errors.Is(err, io.ErrUnexpectedEOF) {
+			// no tests found
+			s.done = true
+			return nil
+		} else if err != nil {
+			return err
+		}
+	}
 
-  s.test = Test{}
-  if err := s.scanHeader(); err != nil {
-    if errors.Is(err, io.ErrUnexpectedEOF) {
-      s.done = true
-      return nil
-    }
-    return err
-  }
-  if err := s.scanInput(); err != nil {
-    return err
-  }
-  if err := s.scanOutput(); err != nil {
-    return err
-  }
-  return nil
+	s.test = Test{}
+	if err := s.scanHeader(); err != nil {
+		if errors.Is(err, io.ErrUnexpectedEOF) {
+			s.done = true
+			return nil
+		}
+		return err
+	}
+	if err := s.scanInput(); err != nil {
+		return err
+	}
+	if err := s.scanOutput(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (s *TestScanner) scanHeader() error {
-  headerLines, err := scanLinesUntilCharLine(s.scanner, "=")
-  if err != nil {
-    return fmt.Errorf("scan until closing === line: %w", err)
-  }
-  for _, line := range headerLines {
-    if err := s.readHeaderLine(line); err != nil {
-      return err
-    }
-  }
-  return nil
+	headerLines, err := scanLinesUntilCharLine(s.scanner, "=")
+	if err != nil {
+		return fmt.Errorf("scan until closing === line: %w", err)
+	}
+	for _, line := range headerLines {
+		if err := s.readHeaderLine(line); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *TestScanner) readHeaderLine(line string) error {
-  trimmed := strings.TrimSpace(line)
-  if trimmed == "" {
-    return nil
-  }
-  firstChar, size := utf8.DecodeRuneInString(line)
-  rest := strings.TrimSpace(trimmed[size:])
-  switch firstChar {
-  case '#':
-    s.test.Name = rest
-    return nil
-  case '$':
-    if s.test.Command != "" {
-      return fmt.Errorf("test %q: found multiple command lines (starting with '$') in header", s.test.Name)
-    }
-    s.test.Command = rest
-    if s.test.Name == "" {
-      s.test.Name = rest
-    }
-    return nil
-  }
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return nil
+	}
+	firstChar, size := utf8.DecodeRuneInString(line)
+	rest := strings.TrimSpace(trimmed[size:])
+	switch firstChar {
+	case '#':
+		s.test.Name = rest
+		return nil
+	case '$':
+		if s.test.Command != "" {
+			return fmt.Errorf("test %q: found multiple command lines (starting with '$') in header", s.test.Name)
+		}
+		s.test.Command = rest
+		if s.test.Name == "" {
+			s.test.Name = rest
+		}
+		return nil
+	}
 
-  if key, value, ok := strings.Cut(trimmed, "="); ok {
-    key = strings.TrimSpace(key)
-    value = strings.TrimSpace(value)
-    if strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`) {
-      if _, err := fmt.Sscanf(value, "%q", &value); err != nil {
-        return fmt.Errorf("test %q: env %q: failed to parse value as quoted string: %w", s.test.Name, key, err)
-      }
-    }
-    if slices.ContainsFunc(s.test.Env, func(e EnvVar) bool {
-      return e.Key == key
-    }) {
-      return fmt.Errorf("test %q: env %q: key specified multiple times", s.test.Name, key)
-    }
+	if key, value, ok := strings.Cut(trimmed, "="); ok {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`) {
+			if _, err := fmt.Sscanf(value, "%q", &value); err != nil {
+				return fmt.Errorf("test %q: env %q: failed to parse value as quoted string: %w", s.test.Name, key, err)
+			}
+		}
+		if slices.ContainsFunc(s.test.Env, func(e EnvVar) bool {
+			return e.Key == key
+		}) {
+			return fmt.Errorf("test %q: env %q: key specified multiple times", s.test.Name, key)
+		}
 
-    s.test.Env = append(s.test.Env, EnvVar{
-      Key:   key,
-      Value: value,
-    })
-    return nil
-  }
+		s.test.Env = append(s.test.Env, EnvVar{
+			Key:   key,
+			Value: value,
+		})
+		return nil
+	}
 
-  return fmt.Errorf("test %q: invalid test header line %q", s.test.Name, trimmed)
+	return fmt.Errorf("test %q: invalid test header line %q", s.test.Name, trimmed)
 }
 
 func (s *TestScanner) scanInput() error {
-  inputLines, err := scanLinesUntilCharLine(s.scanner, "-")
-  if err != nil {
-    return fmt.Errorf("scan test input: %w", err)
-  }
-  s.test.Input = strings.TrimSpace(strings.Join(inputLines, "\n"))
-  return nil
+	inputLines, err := scanLinesUntilCharLine(s.scanner, "-")
+	if err != nil {
+		return fmt.Errorf("scan test input: %w", err)
+	}
+	s.test.Input = strings.TrimSpace(strings.Join(inputLines, "\n"))
+	return nil
 }
 
 func (s *TestScanner) scanOutput() error {
-  outputLines, err := scanLinesUntilCharLine(s.scanner, "=")
-  if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
-    return fmt.Errorf("scan test output: %w", err)
-  }
-  s.test.Output = strings.TrimSpace(strings.Join(outputLines, "\n"))
-  return nil
+	outputLines, err := scanLinesUntilCharLine(s.scanner, "=")
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return fmt.Errorf("scan test output: %w", err)
+	}
+	s.test.Output = strings.TrimSpace(strings.Join(outputLines, "\n"))
+	return nil
 }
 
 func scanLinesUntilCharLine(scanner *bufio.Scanner, char string) ([]string, error) {
-  var lines []string
-  minNumberOfChars := 3
+	var lines []string
+	minNumberOfChars := 3
 
-  for scanner.Scan() {
-    line := strings.Trim(scanner.Text(), "\r")
+	for scanner.Scan() {
+		line := strings.Trim(scanner.Text(), "\r")
 
-    lineFilter := regexp.MustCompile(fmt.Sprintf(`^%s{%d,}$`, regexp.QuoteMeta(char), minNumberOfChars))
-    if lineFilter.MatchString(line) {
-      return lines, nil
-    }
+		lineFilter := regexp.MustCompile(fmt.Sprintf(`^%s{%d,}$`, regexp.QuoteMeta(char), minNumberOfChars))
+		if lineFilter.MatchString(line) {
+			return lines, nil
+		}
 
-    lines = append(lines, line)
-  }
-  if err := scanner.Err(); err != nil {
-    return nil, err
-  }
+		lines = append(lines, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
 
-  return lines, io.ErrUnexpectedEOF
+	return lines, io.ErrUnexpectedEOF
 }

--- a/internal/testcorpus/scanner.go
+++ b/internal/testcorpus/scanner.go
@@ -1,165 +1,168 @@
 package testcorpus
 
 import (
-	"bufio"
-	"errors"
-	"fmt"
-	"io"
-	"slices"
-	"strings"
-	"unicode/utf8"
+  "bufio"
+  "errors"
+  "fmt"
+  "io"
+  "regexp"
+  "slices"
+  "strings"
+  "unicode/utf8"
 )
 
 func NewTestScanner(reader io.Reader) *TestScanner {
-	return &TestScanner{
-		scanner: bufio.NewScanner(reader),
-		first:   true,
-	}
+  return &TestScanner{
+    scanner: bufio.NewScanner(reader),
+    first:   true,
+  }
 }
 
 type TestScanner struct {
-	scanner *bufio.Scanner
+  scanner *bufio.Scanner
 
-	test  Test
-	err   error
-	done  bool
-	first bool
+  test  Test
+  err   error
+  done  bool
+  first bool
 }
 
 func (s *TestScanner) Scan() bool {
-	s.err = s.scanErr()
-	return s.err == nil && !s.done
+  s.err = s.scanErr()
+  return s.err == nil && !s.done
 }
 
 func (s *TestScanner) Test() Test {
-	return s.test
+  return s.test
 }
 
 func (s *TestScanner) Err() error {
-	return s.err
+  return s.err
 }
 
 func (s *TestScanner) scanErr() error {
-	if s.first {
-		s.first = false
-		if _, err := scanLinesUntil(s.scanner, "==="); errors.Is(err, io.ErrUnexpectedEOF) {
-			// no tests found
-			s.done = true
-			return nil
-		} else if err != nil {
-			return err
-		}
-	}
+  if s.first {
+    s.first = false
+    if _, err := scanLinesUntilCharLine(s.scanner, "="); errors.Is(err, io.ErrUnexpectedEOF) {
+      // no tests found
+      s.done = true
+      return nil
+    } else if err != nil {
+      return err
+    }
+  }
 
-	s.test = Test{}
-	if err := s.scanHeader(); err != nil {
-		if errors.Is(err, io.ErrUnexpectedEOF) {
-			s.done = true
-			return nil
-		}
-		return err
-	}
-	if err := s.scanInput(); err != nil {
-		return err
-	}
-	if err := s.scanOutput(); err != nil {
-		return err
-	}
-	return nil
+  s.test = Test{}
+  if err := s.scanHeader(); err != nil {
+    if errors.Is(err, io.ErrUnexpectedEOF) {
+      s.done = true
+      return nil
+    }
+    return err
+  }
+  if err := s.scanInput(); err != nil {
+    return err
+  }
+  if err := s.scanOutput(); err != nil {
+    return err
+  }
+  return nil
 }
 
 func (s *TestScanner) scanHeader() error {
-	headerLines, err := scanLinesUntil(s.scanner, "===")
-	if err != nil {
-		return fmt.Errorf("scan until closing === line: %w", err)
-	}
-	for _, line := range headerLines {
-		if err := s.readHeaderLine(line); err != nil {
-			return err
-		}
-	}
-	return nil
+  headerLines, err := scanLinesUntilCharLine(s.scanner, "=")
+  if err != nil {
+    return fmt.Errorf("scan until closing === line: %w", err)
+  }
+  for _, line := range headerLines {
+    if err := s.readHeaderLine(line); err != nil {
+      return err
+    }
+  }
+  return nil
 }
 
 func (s *TestScanner) readHeaderLine(line string) error {
-	trimmed := strings.TrimSpace(line)
-	if trimmed == "" {
-		return nil
-	}
-	firstChar, size := utf8.DecodeRuneInString(line)
-	rest := strings.TrimSpace(trimmed[size:])
-	switch firstChar {
-	case '#':
-		s.test.Name = rest
-		return nil
-	case '$':
-		if s.test.Command != "" {
-			return fmt.Errorf("test %q: found multiple command lines (starting with '$') in header", s.test.Name)
-		}
-		s.test.Command = rest
-		if s.test.Name == "" {
-			s.test.Name = rest
-		}
-		return nil
-	}
+  trimmed := strings.TrimSpace(line)
+  if trimmed == "" {
+    return nil
+  }
+  firstChar, size := utf8.DecodeRuneInString(line)
+  rest := strings.TrimSpace(trimmed[size:])
+  switch firstChar {
+  case '#':
+    s.test.Name = rest
+    return nil
+  case '$':
+    if s.test.Command != "" {
+      return fmt.Errorf("test %q: found multiple command lines (starting with '$') in header", s.test.Name)
+    }
+    s.test.Command = rest
+    if s.test.Name == "" {
+      s.test.Name = rest
+    }
+    return nil
+  }
 
-	if key, value, ok := strings.Cut(trimmed, "="); ok {
-		key = strings.TrimSpace(key)
-		value = strings.TrimSpace(value)
-		if strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`) {
-			if _, err := fmt.Sscanf(value, "%q", &value); err != nil {
-				return fmt.Errorf("test %q: env %q: failed to parse value as quoted string: %w", s.test.Name, key, err)
-			}
-		}
-		if slices.ContainsFunc(s.test.Env, func(e EnvVar) bool {
-			return e.Key == key
-		}) {
-			return fmt.Errorf("test %q: env %q: key specified multiple times", s.test.Name, key)
-		}
+  if key, value, ok := strings.Cut(trimmed, "="); ok {
+    key = strings.TrimSpace(key)
+    value = strings.TrimSpace(value)
+    if strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`) {
+      if _, err := fmt.Sscanf(value, "%q", &value); err != nil {
+        return fmt.Errorf("test %q: env %q: failed to parse value as quoted string: %w", s.test.Name, key, err)
+      }
+    }
+    if slices.ContainsFunc(s.test.Env, func(e EnvVar) bool {
+      return e.Key == key
+    }) {
+      return fmt.Errorf("test %q: env %q: key specified multiple times", s.test.Name, key)
+    }
 
-		s.test.Env = append(s.test.Env, EnvVar{
-			Key:   key,
-			Value: value,
-		})
-		return nil
-	}
+    s.test.Env = append(s.test.Env, EnvVar{
+      Key:   key,
+      Value: value,
+    })
+    return nil
+  }
 
-	return fmt.Errorf("test %q: invalid test header line %q", s.test.Name, trimmed)
+  return fmt.Errorf("test %q: invalid test header line %q", s.test.Name, trimmed)
 }
 
 func (s *TestScanner) scanInput() error {
-	inputLines, err := scanLinesUntil(s.scanner, "---")
-	if err != nil {
-		return fmt.Errorf("scan test input: %w", err)
-	}
-	s.test.Input = strings.TrimSpace(strings.Join(inputLines, "\n"))
-	return nil
+  inputLines, err := scanLinesUntilCharLine(s.scanner, "-")
+  if err != nil {
+    return fmt.Errorf("scan test input: %w", err)
+  }
+  s.test.Input = strings.TrimSpace(strings.Join(inputLines, "\n"))
+  return nil
 }
 
 func (s *TestScanner) scanOutput() error {
-	outputLines, err := scanLinesUntil(s.scanner, "===")
-	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
-		return fmt.Errorf("scan test output: %w", err)
-	}
-	s.test.Output = strings.TrimSpace(strings.Join(outputLines, "\n"))
-	return nil
+  outputLines, err := scanLinesUntilCharLine(s.scanner, "=")
+  if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
+    return fmt.Errorf("scan test output: %w", err)
+  }
+  s.test.Output = strings.TrimSpace(strings.Join(outputLines, "\n"))
+  return nil
 }
 
-func scanLinesUntil(scanner *bufio.Scanner, linePrefix string) ([]string, error) {
-	var lines []string
+func scanLinesUntilCharLine(scanner *bufio.Scanner, char string) ([]string, error) {
+  var lines []string
+  minNumberOfChars := 3
 
-	for scanner.Scan() {
-		line := strings.Trim(scanner.Text(), "\r")
+  for scanner.Scan() {
+    line := strings.Trim(scanner.Text(), "\r")
 
-		if strings.HasPrefix(line, linePrefix) {
-			return lines, nil
-		}
+    lineFilter := regexp.MustCompile(fmt.Sprintf(`^%s{%d,}$`, regexp.QuoteMeta(char), minNumberOfChars))
+    if lineFilter.MatchString(line) {
+      return lines, nil
+    }
 
-		lines = append(lines, line)
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
+    lines = append(lines, line)
+  }
+  if err := scanner.Err(); err != nil {
+    return nil, err
+  }
 
-	return lines, io.ErrUnexpectedEOF
+  return lines, io.ErrUnexpectedEOF
 }

--- a/printer/kubectl_diff.go
+++ b/printer/kubectl_diff.go
@@ -1,45 +1,45 @@
 package printer
 
 import (
-  "bufio"
-  "fmt"
-  "github.com/kubecolor/kubecolor/config"
-  "io"
-  "regexp"
+	"bufio"
+	"fmt"
+	"github.com/kubecolor/kubecolor/config"
+	"io"
+	"regexp"
 )
 
 type DiffPrinter struct {
-  Theme *config.Theme
+	Theme *config.Theme
 }
 
 func (p *DiffPrinter) Print(r io.Reader, w io.Writer) {
-  scanner := bufio.NewScanner(r)
-  for scanner.Scan() {
-    line := scanner.Text()
-    if line == "" {
-      fmt.Fprintln(w, line)
-      continue
-    }
-    parsedLine := p.parseLine(line)
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			fmt.Fprintln(w, line)
+			continue
+		}
+		parsedLine := p.parseLine(line)
 
-    fmt.Fprintln(w, parsedLine)
-  }
+		fmt.Fprintln(w, parsedLine)
+	}
 }
 
 func (p *DiffPrinter) parseLine(line string) string {
-  theme := p.Theme.Diff
-  switch {
-  // All only lines, that starts with a single "+"and anything afterward
-  // e.g. + foo
-  // not allowed: ++ foo
-  case regexp.MustCompile(`^\+[^+]+.*$`).MatchString(line):
-    return theme.Added.Render(line)
-  // All only lines, that starts with a single "-" and anything afterward
-  // e.g. - foo
-  // not allowed: -- foo
-  case regexp.MustCompile(`^-[^-]+.*$`).MatchString(line):
-    return theme.Removed.Render(line)
-  default:
-    return theme.Unchanged.Render(line)
-  }
+	theme := p.Theme.Diff
+	switch {
+	// All only lines, that starts with a single "+"and anything afterward
+	// e.g. + foo
+	// not allowed: ++ foo
+	case regexp.MustCompile(`^\+[^+]+.*$`).MatchString(line):
+		return theme.Added.Render(line)
+	// All only lines, that starts with a single "-" and anything afterward
+	// e.g. - foo
+	// not allowed: -- foo
+	case regexp.MustCompile(`^-[^-]+.*$`).MatchString(line):
+		return theme.Removed.Render(line)
+	default:
+		return theme.Unchanged.Render(line)
+	}
 }

--- a/printer/kubectl_diff.go
+++ b/printer/kubectl_diff.go
@@ -26,9 +26,9 @@ func (p *DiffPrinter) Print(r io.Reader, w io.Writer) {
 	}
 }
 
-func (p *DiffPrinter) parseLine(line string) interface{} {
+func (p *DiffPrinter) parseLine(line string) string {
 	theme := p.Theme.Diff
-	switch true {
+	switch {
 	case strings.HasPrefix(line, "+"):
 		return theme.Added.Render(line)
 	case strings.HasPrefix(line, "-"):

--- a/printer/kubectl_diff.go
+++ b/printer/kubectl_diff.go
@@ -1,39 +1,45 @@
 package printer
 
 import (
-	"bufio"
-	"fmt"
-	"github.com/kubecolor/kubecolor/config"
-	"io"
-	"strings"
+  "bufio"
+  "fmt"
+  "github.com/kubecolor/kubecolor/config"
+  "io"
+  "regexp"
 )
 
 type DiffPrinter struct {
-	Theme *config.Theme
+  Theme *config.Theme
 }
 
 func (p *DiffPrinter) Print(r io.Reader, w io.Writer) {
-	scanner := bufio.NewScanner(r)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "" {
-			fmt.Fprintln(w, line)
-			continue
-		}
-		parsedLine := p.parseLine(line)
+  scanner := bufio.NewScanner(r)
+  for scanner.Scan() {
+    line := scanner.Text()
+    if line == "" {
+      fmt.Fprintln(w, line)
+      continue
+    }
+    parsedLine := p.parseLine(line)
 
-		fmt.Fprintln(w, parsedLine)
-	}
+    fmt.Fprintln(w, parsedLine)
+  }
 }
 
 func (p *DiffPrinter) parseLine(line string) string {
-	theme := p.Theme.Diff
-	switch {
-	case strings.HasPrefix(line, "+"):
-		return theme.Added.Render(line)
-	case strings.HasPrefix(line, "-"):
-		return theme.Removed.Render(line)
-	default:
-		return theme.Unchanged.Render(line)
-	}
+  theme := p.Theme.Diff
+  switch {
+  // All only lines, that starts with a single "+"and anything afterward
+  // e.g. + foo
+  // not allowed: ++ foo
+  case regexp.MustCompile(`^\+[^+]+.*$`).MatchString(line):
+    return theme.Added.Render(line)
+  // All only lines, that starts with a single "-" and anything afterward
+  // e.g. - foo
+  // not allowed: -- foo
+  case regexp.MustCompile(`^-[^-]+.*$`).MatchString(line):
+    return theme.Removed.Render(line)
+  default:
+    return theme.Unchanged.Render(line)
+  }
 }

--- a/printer/kubectl_diff.go
+++ b/printer/kubectl_diff.go
@@ -1,0 +1,39 @@
+package printer
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/kubecolor/kubecolor/config"
+	"io"
+	"strings"
+)
+
+type DiffPrinter struct {
+	Theme *config.Theme
+}
+
+func (p *DiffPrinter) Print(r io.Reader, w io.Writer) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			fmt.Fprintln(w, line)
+			continue
+		}
+		parsedLine := p.parseLine(line)
+
+		fmt.Fprintln(w, parsedLine)
+	}
+}
+
+func (p *DiffPrinter) parseLine(line string) interface{} {
+	theme := p.Theme.Diff
+	switch true {
+	case strings.HasPrefix(line, "+"):
+		return theme.Added.Render(line)
+	case strings.HasPrefix(line, "-"):
+		return theme.Removed.Render(line)
+	default:
+		return theme.Unchanged.Render(line)
+	}
+}

--- a/printer/kubectl_diff.go
+++ b/printer/kubectl_diff.go
@@ -3,9 +3,10 @@ package printer
 import (
 	"bufio"
 	"fmt"
-	"github.com/kubecolor/kubecolor/config"
 	"io"
-	"regexp"
+	"strings"
+
+	"github.com/kubecolor/kubecolor/config"
 )
 
 type DiffPrinter struct {

--- a/printer/kubectl_output_colored_printer.go
+++ b/printer/kubectl_output_colored_printer.go
@@ -129,6 +129,9 @@ func (p *KubectlOutputColoredPrinter) getPrinter() Printer {
 			Theme: p.Theme,
 		}
 
+	case kubectl.Diff:
+		return &DiffPrinter{Theme: p.Theme}
+
 	case
 		kubectl.Apply,
 		kubectl.Create,

--- a/printer/kubectl_output_colored_printer.go
+++ b/printer/kubectl_output_colored_printer.go
@@ -89,10 +89,13 @@ func (p *KubectlOutputColoredPrinter) getPrinter() Printer {
 					return column
 				},
 			)
+
 		case kubectl.OutputJSON:
 			return &JSONPrinter{Theme: p.Theme}
+
 		case kubectl.OutputYAML:
 			return &YAMLPrinter{Theme: p.Theme}
+
 		default:
 			return &LogsPrinter{Theme: p.Theme}
 		}
@@ -112,6 +115,7 @@ func (p *KubectlOutputColoredPrinter) getPrinter() Printer {
 			Theme:     p.Theme,
 			Recursive: p.Recursive,
 		}
+
 	case kubectl.Version:
 		switch {
 		case p.SubcommandInfo.Output == kubectl.OutputJSON:
@@ -124,6 +128,7 @@ func (p *KubectlOutputColoredPrinter) getPrinter() Printer {
 				KubecolorVersion: p.KubecolorVersion,
 			}
 		}
+
 	case kubectl.Options:
 		return &OptionsPrinter{
 			Theme: p.Theme,
@@ -159,6 +164,7 @@ func (p *KubectlOutputColoredPrinter) getPrinter() Printer {
 					"unchanged":  p.Theme.Apply.Unchanged,
 				},
 			}
+
 		case kubectl.Create:
 			return &VerbPrinter{
 				DryRunColor:   p.Theme.Create.DryRun,
@@ -167,6 +173,7 @@ func (p *KubectlOutputColoredPrinter) getPrinter() Printer {
 					"created": p.Theme.Create.Created,
 				},
 			}
+
 		case kubectl.Delete:
 			return &VerbPrinter{
 				DryRunColor:   p.Theme.Delete.DryRun,
@@ -175,6 +182,7 @@ func (p *KubectlOutputColoredPrinter) getPrinter() Printer {
 					"deleted": p.Theme.Delete.Deleted,
 				},
 			}
+
 		case kubectl.Expose:
 			return &VerbPrinter{
 				DryRunColor:   p.Theme.Expose.DryRun,
@@ -183,6 +191,7 @@ func (p *KubectlOutputColoredPrinter) getPrinter() Printer {
 					"exposed": p.Theme.Expose.Exposed,
 				},
 			}
+
 		case kubectl.Patch:
 			return &VerbPrinter{
 				DryRunColor:   p.Theme.Patch.DryRun,
@@ -191,6 +200,7 @@ func (p *KubectlOutputColoredPrinter) getPrinter() Printer {
 					"patched": p.Theme.Patch.Patched,
 				},
 			}
+
 		case kubectl.Scale:
 			return &VerbPrinter{
 				DryRunColor:   p.Theme.Scale.DryRun,
@@ -199,6 +209,7 @@ func (p *KubectlOutputColoredPrinter) getPrinter() Printer {
 					"scaled": p.Theme.Scale.Scaled,
 				},
 			}
+
 		case kubectl.Rollout:
 			return &VerbPrinter{
 				DryRunColor:   p.Theme.Rollout.DryRun,
@@ -210,6 +221,7 @@ func (p *KubectlOutputColoredPrinter) getPrinter() Printer {
 					"restarted":   p.Theme.Rollout.Restarted,
 				},
 			}
+
 		case kubectl.Drain:
 			return &VerbPrinter{
 				DryRunColor:   p.Theme.Drain.DryRun,
@@ -223,6 +235,7 @@ func (p *KubectlOutputColoredPrinter) getPrinter() Printer {
 					"evicting pod": p.Theme.Drain.EvictingPod,
 				},
 			}
+
 		case kubectl.Uncordon:
 			return &VerbPrinter{
 				DryRunColor:   p.Theme.Uncordon.DryRun,

--- a/test/corpus/kubectl_diff.txt
+++ b/test/corpus/kubectl_diff.txt
@@ -1,0 +1,32 @@
+================================================================================
+# only lines added
+$ kubectl diff -f deployment.yaml
+================================================================================
+
+diff -u -N /tmp/LIVE-2359820259/apps.v1.Deployment.kubecolor.nginx /tmp/MERGED-2636529718/apps.v1.Deployment.kubecolor.nginx
+
+--------------------------------------------------------------------------------
+
+[90;3mdiff -u -N /tmp/LIVE-2359820259/apps.v1.Deployment.kubecolor.nginx /tmp/MERGED-2636529718/apps.v1.Deployment.kubecolor.nginx[0m
+
+================================================================================
+# only lines removed
+$ kubectl diff -f deployment.yaml
+================================================================================
+
+diff -u -N /tmp/LIVE-3365154021/apps.v1.Deployment.kubecolor.nginx /tmp/MERGED-3382466440/apps.v1.Deployment.kubecolor.nginx
+
+--------------------------------------------------------------------------------
+
+[90;3mdiff -u -N /tmp/LIVE-3365154021/apps.v1.Deployment.kubecolor.nginx /tmp/MERGED-3382466440/apps.v1.Deployment.kubecolor.nginx[0m
+
+================================================================================
+# lines added and removed
+$ kubectl diff -f deployment.yaml
+================================================================================
+
+diff -u -N /tmp/LIVE-2028647702/apps.v1.Deployment.kubecolor.nginx /tmp/MERGED-30391469/apps.v1.Deployment.kubecolor.nginx
+
+--------------------------------------------------------------------------------
+
+[90;3mdiff -u -N /tmp/LIVE-2028647702/apps.v1.Deployment.kubecolor.nginx /tmp/MERGED-30391469/apps.v1.Deployment.kubecolor.nginx[0m

--- a/test/corpus/kubectl_diff.txt
+++ b/test/corpus/kubectl_diff.txt
@@ -27,27 +27,27 @@ diff -u -N /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-2513085857/apps
 
 --------------------------------------------------------------------------------
 
-[90mdiff -u -N /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-2513085857/apps.v1.Deployment.default.test /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1097005791/apps.v1.Deployment.default.test[0m
-[90m--- /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-2513085857/apps.v1.Deployment.default.test    2024-11-24 22:17:35[0m
-[90m+++ /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1097005791/apps.v1.Deployment.default.test  2024-11-24 22:17:35[0m
-[90m@@ -6,7 +6,7 @@[0m
-[90m     kubectl.kubernetes.io/last-applied-configuration: |[0m
-[90m       {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"labels":{"app":"test"},"name":"test","namespace":"default"},"spec":{"replicas":3,"selector":{"matchLabels":{"app":"test"}},"strategy":{},"template":{"metadata":{"labels":{"app":"test"}},"spec":{"containers":[{"image":"httpd","name":"httpd","resources":{}}]}}}}[0m
-[90m   creationTimestamp: "2024-11-24T20:26:26Z"[0m
+[90;3mdiff -u -N /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-2513085857/apps.v1.Deployment.default.test /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1097005791/apps.v1.Deployment.default.test[0m
+[90;3m--- /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-2513085857/apps.v1.Deployment.default.test    2024-11-24 22:17:35[0m
+[90;3m+++ /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1097005791/apps.v1.Deployment.default.test  2024-11-24 22:17:35[0m
+[90;3m@@ -6,7 +6,7 @@[0m
+[90;3m     kubectl.kubernetes.io/last-applied-configuration: |[0m
+[90;3m       {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"labels":{"app":"test"},"name":"test","namespace":"default"},"spec":{"replicas":3,"selector":{"matchLabels":{"app":"test"}},"strategy":{},"template":{"metadata":{"labels":{"app":"test"}},"spec":{"containers":[{"image":"httpd","name":"httpd","resources":{}}]}}}}[0m
+[90;3m   creationTimestamp: "2024-11-24T20:26:26Z"[0m
 [31m-  generation: 2[0m
 [32m+  generation: 3[0m
-[90m   labels:[0m
-[90m     app: test[0m
-[90m   name: test[0m
-[90m@@ -32,7 +32,7 @@[0m
-[90m         app: test[0m
-[90m     spec:[0m
-[90m       containers:[0m
+[90;3m   labels:[0m
+[90;3m     app: test[0m
+[90;3m   name: test[0m
+[90;3m@@ -32,7 +32,7 @@[0m
+[90;3m         app: test[0m
+[90;3m     spec:[0m
+[90;3m       containers:[0m
 [31m-      - image: httpd[0m
 [32m+      - image: httpd:latest[0m
-[90m         imagePullPolicy: Always[0m
-[90m         name: httpd[0m
-[90m         resources: {}[0m
+[90;3m         imagePullPolicy: Always[0m
+[90;3m         name: httpd[0m
+[90;3m         resources: {}[0m
 
 ================================================================================
 # contains only added lines
@@ -102,10 +102,10 @@ diff -u -N /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-359469156/apps.
 
 --------------------------------------------------------------------------------
 
-[90mdiff -u -N /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-359469156/apps.v1.Deployment.default.add /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1017119628/apps.v1.Deployment.default.add[0m
-[90m--- /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-359469156/apps.v1.Deployment.default.add      2024-11-24 22:21:44[0m
-[90m+++ /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1017119628/apps.v1.Deployment.default.add   2024-11-24 22:21:44[0m
-[90m@@ -0,0 +1,41 @@[0m
+[90;3mdiff -u -N /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-359469156/apps.v1.Deployment.default.add /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1017119628/apps.v1.Deployment.default.add[0m
+[90;3m--- /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-359469156/apps.v1.Deployment.default.add      2024-11-24 22:21:44[0m
+[90;3m+++ /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1017119628/apps.v1.Deployment.default.add   2024-11-24 22:21:44[0m
+[90;3m@@ -0,0 +1,41 @@[0m
 [32m+apiVersion: apps/v1[0m
 [32m+kind: Deployment[0m
 [32m+metadata:[0m
@@ -177,24 +177,24 @@ diff -u -N /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-480322945/apps.
 
 --------------------------------------------------------------------------------
 
-[90mdiff -u -N /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-480322945/apps.v1.Deployment.default.test /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1809976568/apps.v1.Deployment.default.test[0m
-[90m--- /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-480322945/apps.v1.Deployment.default.test     2024-11-24 21:28:39[0m
-[90m+++ /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1809976568/apps.v1.Deployment.default.test  2024-11-24 21:28:39[0m
-[90m@@ -6,7 +6,7 @@[0m
-[90m     kubectl.kubernetes.io/last-applied-configuration: |[0m
-[90m       {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"labels":{"app":"test"},"name":"test","namespace":"default"},"spec":{"replicas":3,"selector":{"matchLabels":{"app":"test"}},"strategy":{},"template":{"metadata":{"labels":{"app":"test"}},"spec":{"containers":[{"env":[{"name":"MY_ENV","value":"my_value"}],"image":"httpd","name":"httpd","resources":{}}]}}}}[0m
-[90m   creationTimestamp: "2024-11-24T20:26:26Z"[0m
+[90;3mdiff -u -N /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-480322945/apps.v1.Deployment.default.test /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1809976568/apps.v1.Deployment.default.test[0m
+[90;3m--- /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-480322945/apps.v1.Deployment.default.test     2024-11-24 21:28:39[0m
+[90;3m+++ /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1809976568/apps.v1.Deployment.default.test  2024-11-24 21:28:39[0m
+[90;3m@@ -6,7 +6,7 @@[0m
+[90;3m     kubectl.kubernetes.io/last-applied-configuration: |[0m
+[90;3m       {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"labels":{"app":"test"},"name":"test","namespace":"default"},"spec":{"replicas":3,"selector":{"matchLabels":{"app":"test"}},"strategy":{},"template":{"metadata":{"labels":{"app":"test"}},"spec":{"containers":[{"env":[{"name":"MY_ENV","value":"my_value"}],"image":"httpd","name":"httpd","resources":{}}]}}}}[0m
+[90;3m   creationTimestamp: "2024-11-24T20:26:26Z"[0m
 [31m-  generation: 1[0m
 [32m+  generation: 2[0m
-[90m   labels:[0m
-[90m     app: test[0m
-[90m   name: test[0m
-[90m@@ -34,7 +34,7 @@[0m
-[90m       containers:[0m
-[90m       - env:[0m
-[90m         - name: MY_ENV[0m
+[90;3m   labels:[0m
+[90;3m     app: test[0m
+[90;3m   name: test[0m
+[90;3m@@ -34,7 +34,7 @@[0m
+[90;3m       containers:[0m
+[90;3m       - env:[0m
+[90;3m         - name: MY_ENV[0m
 [31m-          value: my_value[0m
 [32m+          value: test[0m
-[90m         image: httpd[0m
-[90m         imagePullPolicy: Always[0m
-[90m         name: httpd[0m
+[90;3m         image: httpd[0m
+[90;3m         imagePullPolicy: Always[0m
+[90;3m         name: httpd[0m

--- a/test/corpus/kubectl_diff.txt
+++ b/test/corpus/kubectl_diff.txt
@@ -1,32 +1,200 @@
 ================================================================================
-# only lines added
-$ kubectl diff -f deployment.yaml
+# contain added, removed, and unchanged resources
+$ kubectl diff -f service.yaml
 ================================================================================
 
-diff -u -N /tmp/LIVE-2359820259/apps.v1.Deployment.kubecolor.nginx /tmp/MERGED-2636529718/apps.v1.Deployment.kubecolor.nginx
+diff -u -N /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-2513085857/apps.v1.Deployment.default.test /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1097005791/apps.v1.Deployment.default.test
+--- /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-2513085857/apps.v1.Deployment.default.test    2024-11-24 22:17:35
++++ /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1097005791/apps.v1.Deployment.default.test  2024-11-24 22:17:35
+@@ -6,7 +6,7 @@
+     kubectl.kubernetes.io/last-applied-configuration: |
+       {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"labels":{"app":"test"},"name":"test","namespace":"default"},"spec":{"replicas":3,"selector":{"matchLabels":{"app":"test"}},"strategy":{},"template":{"metadata":{"labels":{"app":"test"}},"spec":{"containers":[{"image":"httpd","name":"httpd","resources":{}}]}}}}
+   creationTimestamp: "2024-11-24T20:26:26Z"
+-  generation: 2
++  generation: 3
+   labels:
+     app: test
+   name: test
+@@ -32,7 +32,7 @@
+         app: test
+     spec:
+       containers:
+-      - image: httpd
++      - image: httpd:latest
+         imagePullPolicy: Always
+         name: httpd
+         resources: {}
 
 --------------------------------------------------------------------------------
 
-[90;3mdiff -u -N /tmp/LIVE-2359820259/apps.v1.Deployment.kubecolor.nginx /tmp/MERGED-2636529718/apps.v1.Deployment.kubecolor.nginx[0m
+[90mdiff -u -N /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-2513085857/apps.v1.Deployment.default.test /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1097005791/apps.v1.Deployment.default.test[0m
+[90m--- /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-2513085857/apps.v1.Deployment.default.test    2024-11-24 22:17:35[0m
+[90m+++ /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1097005791/apps.v1.Deployment.default.test  2024-11-24 22:17:35[0m
+[90m@@ -6,7 +6,7 @@[0m
+[90m     kubectl.kubernetes.io/last-applied-configuration: |[0m
+[90m       {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"labels":{"app":"test"},"name":"test","namespace":"default"},"spec":{"replicas":3,"selector":{"matchLabels":{"app":"test"}},"strategy":{},"template":{"metadata":{"labels":{"app":"test"}},"spec":{"containers":[{"image":"httpd","name":"httpd","resources":{}}]}}}}[0m
+[90m   creationTimestamp: "2024-11-24T20:26:26Z"[0m
+[31m-  generation: 2[0m
+[32m+  generation: 3[0m
+[90m   labels:[0m
+[90m     app: test[0m
+[90m   name: test[0m
+[90m@@ -32,7 +32,7 @@[0m
+[90m         app: test[0m
+[90m     spec:[0m
+[90m       containers:[0m
+[31m-      - image: httpd[0m
+[32m+      - image: httpd:latest[0m
+[90m         imagePullPolicy: Always[0m
+[90m         name: httpd[0m
+[90m         resources: {}[0m
 
 ================================================================================
-# only lines removed
+# contains only added lines
 $ kubectl diff -f deployment.yaml
 ================================================================================
 
-diff -u -N /tmp/LIVE-3365154021/apps.v1.Deployment.kubecolor.nginx /tmp/MERGED-3382466440/apps.v1.Deployment.kubecolor.nginx
+diff -u -N /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-359469156/apps.v1.Deployment.default.add /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1017119628/apps.v1.Deployment.default.add
+--- /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-359469156/apps.v1.Deployment.default.add      2024-11-24 22:21:44
++++ /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1017119628/apps.v1.Deployment.default.add   2024-11-24 22:21:44
+@@ -0,0 +1,41 @@
++apiVersion: apps/v1
++kind: Deployment
++metadata:
++  creationTimestamp: "2024-11-24T21:21:44Z"
++  generation: 1
++  labels:
++    app: add
++  name: add
++  namespace: default
++  uid: 2597274a-a985-4dd8-8a23-46bdad8c0311
++spec:
++  progressDeadlineSeconds: 600
++  replicas: 3
++  revisionHistoryLimit: 10
++  selector:
++    matchLabels:
++      app: add
++  strategy:
++    rollingUpdate:
++      maxSurge: 25%
++      maxUnavailable: 25%
++    type: RollingUpdate
++  template:
++    metadata:
++      creationTimestamp: null
++      labels:
++        app: add
++    spec:
++      containers:
++      - image: httpd:latest
++        imagePullPolicy: Always
++        name: httpd
++        resources: {}
++        terminationMessagePath: /dev/termination-log
++        terminationMessagePolicy: File
++      dnsPolicy: ClusterFirst
++      restartPolicy: Always
++      schedulerName: default-scheduler
++      securityContext: {}
++      terminationGracePeriodSeconds: 30
++status: {}
 
 --------------------------------------------------------------------------------
 
-[90;3mdiff -u -N /tmp/LIVE-3365154021/apps.v1.Deployment.kubecolor.nginx /tmp/MERGED-3382466440/apps.v1.Deployment.kubecolor.nginx[0m
+[90mdiff -u -N /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-359469156/apps.v1.Deployment.default.add /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1017119628/apps.v1.Deployment.default.add[0m
+[90m--- /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-359469156/apps.v1.Deployment.default.add      2024-11-24 22:21:44[0m
+[90m+++ /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1017119628/apps.v1.Deployment.default.add   2024-11-24 22:21:44[0m
+[90m@@ -0,0 +1,41 @@[0m
+[32m+apiVersion: apps/v1[0m
+[32m+kind: Deployment[0m
+[32m+metadata:[0m
+[32m+  creationTimestamp: "2024-11-24T21:21:44Z"[0m
+[32m+  generation: 1[0m
+[32m+  labels:[0m
+[32m+    app: add[0m
+[32m+  name: add[0m
+[32m+  namespace: default[0m
+[32m+  uid: 2597274a-a985-4dd8-8a23-46bdad8c0311[0m
+[32m+spec:[0m
+[32m+  progressDeadlineSeconds: 600[0m
+[32m+  replicas: 3[0m
+[32m+  revisionHistoryLimit: 10[0m
+[32m+  selector:[0m
+[32m+    matchLabels:[0m
+[32m+      app: add[0m
+[32m+  strategy:[0m
+[32m+    rollingUpdate:[0m
+[32m+      maxSurge: 25%[0m
+[32m+      maxUnavailable: 25%[0m
+[32m+    type: RollingUpdate[0m
+[32m+  template:[0m
+[32m+    metadata:[0m
+[32m+      creationTimestamp: null[0m
+[32m+      labels:[0m
+[32m+        app: add[0m
+[32m+    spec:[0m
+[32m+      containers:[0m
+[32m+      - image: httpd:latest[0m
+[32m+        imagePullPolicy: Always[0m
+[32m+        name: httpd[0m
+[32m+        resources: {}[0m
+[32m+        terminationMessagePath: /dev/termination-log[0m
+[32m+        terminationMessagePolicy: File[0m
+[32m+      dnsPolicy: ClusterFirst[0m
+[32m+      restartPolicy: Always[0m
+[32m+      schedulerName: default-scheduler[0m
+[32m+      securityContext: {}[0m
+[32m+      terminationGracePeriodSeconds: 30[0m
+[32m+status: {}[0m
 
 ================================================================================
-# lines added and removed
+# contains unchanged lines, which starts with `(space)-`
 $ kubectl diff -f deployment.yaml
 ================================================================================
 
-diff -u -N /tmp/LIVE-2028647702/apps.v1.Deployment.kubecolor.nginx /tmp/MERGED-30391469/apps.v1.Deployment.kubecolor.nginx
+diff -u -N /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-480322945/apps.v1.Deployment.default.test /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1809976568/apps.v1.Deployment.default.test
+--- /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-480322945/apps.v1.Deployment.default.test     2024-11-24 21:28:39
++++ /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1809976568/apps.v1.Deployment.default.test  2024-11-24 21:28:39
+@@ -6,7 +6,7 @@
+     kubectl.kubernetes.io/last-applied-configuration: |
+       {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"labels":{"app":"test"},"name":"test","namespace":"default"},"spec":{"replicas":3,"selector":{"matchLabels":{"app":"test"}},"strategy":{},"template":{"metadata":{"labels":{"app":"test"}},"spec":{"containers":[{"env":[{"name":"MY_ENV","value":"my_value"}],"image":"httpd","name":"httpd","resources":{}}]}}}}
+   creationTimestamp: "2024-11-24T20:26:26Z"
+-  generation: 1
++  generation: 2
+   labels:
+     app: test
+   name: test
+@@ -34,7 +34,7 @@
+       containers:
+       - env:
+         - name: MY_ENV
+-          value: my_value
++          value: test
+         image: httpd
+         imagePullPolicy: Always
+         name: httpd
 
 --------------------------------------------------------------------------------
 
-[90;3mdiff -u -N /tmp/LIVE-2028647702/apps.v1.Deployment.kubecolor.nginx /tmp/MERGED-30391469/apps.v1.Deployment.kubecolor.nginx[0m
+[90mdiff -u -N /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-480322945/apps.v1.Deployment.default.test /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1809976568/apps.v1.Deployment.default.test[0m
+[90m--- /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/LIVE-480322945/apps.v1.Deployment.default.test     2024-11-24 21:28:39[0m
+[90m+++ /var/folders/rn/v1vhmlnx0h94rzcdk2rwqy_r0000gn/T/MERGED-1809976568/apps.v1.Deployment.default.test  2024-11-24 21:28:39[0m
+[90m@@ -6,7 +6,7 @@[0m
+[90m     kubectl.kubernetes.io/last-applied-configuration: |[0m
+[90m       {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"labels":{"app":"test"},"name":"test","namespace":"default"},"spec":{"replicas":3,"selector":{"matchLabels":{"app":"test"}},"strategy":{},"template":{"metadata":{"labels":{"app":"test"}},"spec":{"containers":[{"env":[{"name":"MY_ENV","value":"my_value"}],"image":"httpd","name":"httpd","resources":{}}]}}}}[0m
+[90m   creationTimestamp: "2024-11-24T20:26:26Z"[0m
+[31m-  generation: 1[0m
+[32m+  generation: 2[0m
+[90m   labels:[0m
+[90m     app: test[0m
+[90m   name: test[0m
+[90m@@ -34,7 +34,7 @@[0m
+[90m       containers:[0m
+[90m       - env:[0m
+[90m         - name: MY_ENV[0m
+[31m-          value: my_value[0m
+[32m+          value: test[0m
+[90m         image: httpd[0m
+[90m         imagePullPolicy: Always[0m
+[90m         name: httpd[0m


### PR DESCRIPTION
# Description

<!-- Summarize your PR. Give some context and introduction to the changes -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (fixes an issue)
- [x] New feature (added functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (doesn't directly affect users, e.g refactoring or CI/CD changes)
- [ ] Is a documentation update
- [x] Requires further documentation updates (on https://kubecolor.github.io/)

## Changes

<!-- What was changed, technically? -->

- Added Printer for `kubectl diff`
  - it will render added lines as addition
  - and removed lines as deletion
  - untouched lines are rendered as ignored

## Motivation

<!-- Why you think we should change it? -->

View Issue #190 

## Related issue (if exists)

<!-- remove if no related issue -->

Closes #190
