### PR TITLE
Update Go to 1.23.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.22.7 AS build
+FROM docker.io/library/golang:1.23.4 AS build
 
 WORKDIR /go/src/kubecolor
 COPY go.mod go.sum .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubecolor/kubecolor
 
-go 1.22.7
+go 1.23.4
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0


### PR DESCRIPTION
# Description

Updates Go to 1.23.4

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (doesn't directly affect users, e.g refactoring or CI/CD changes)

## Changes

- Changed version in Dockerfile
- Changed version in go.mod

## Motivation

Stay up-to-date, also #205 requires Go 1.23.0 or later

## Related issue (if exists)

none
