### PR TITLE
bugfix: Fix completion of flag values (with equal sign, as in: `--namespace=...`)

### DIFF
--- a/command/complete_test.go
+++ b/command/complete_test.go
@@ -1,0 +1,88 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/kubecolor/kubecolor/testutil"
+)
+
+func TestFilterCompleteResults(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []CompleteArg
+		toComplete string
+		want       []CompleteArg
+	}{
+		{
+			name:       "empty",
+			args:       []CompleteArg{},
+			toComplete: "",
+			want:       []CompleteArg{},
+		},
+
+		{
+			name: "filter flags by prefix",
+			args: []CompleteArg{
+				{Name: "--kubeconfig"},
+				{Name: "--plain-foo"},
+				{Name: "--plain-bar"},
+				{Name: "--template"},
+				{Name: "--watch"},
+			},
+			toComplete: "--plain",
+			want: []CompleteArg{
+				//{Name: "--kubeconfig"},
+				{Name: "--plain-foo"},
+				{Name: "--plain-bar"},
+				//{Name: "--template"},
+				//{Name: "--watch"},
+			},
+		},
+
+		{
+			name: "filter args by prefix",
+			args: []CompleteArg{
+				{Name: "default"},
+				{Name: "kube-node-lease"},
+				{Name: "kube-public"},
+				{Name: "kube-system"},
+				{Name: "metrics"},
+			},
+			toComplete: "kube",
+			want: []CompleteArg{
+				//{Name: "default"},
+				{Name: "kube-node-lease"},
+				{Name: "kube-public"},
+				{Name: "kube-system"},
+				//{Name: "metrics"},
+			},
+		},
+
+		{
+			// https://github.com/kubecolor/kubecolor/issues/207
+			name: "filter flag value",
+			args: []CompleteArg{
+				{Name: "default"},
+				{Name: "kube-node-lease"},
+				{Name: "kube-public"},
+				{Name: "kube-system"},
+				{Name: "metrics"},
+			},
+			toComplete: "-n=kube",
+			want: []CompleteArg{
+				//{Name: "default"},
+				{Name: "kube-node-lease"},
+				{Name: "kube-public"},
+				{Name: "kube-system"},
+				//{Name: "metrics"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filterCompleteResults(tc.args, tc.toComplete)
+			testutil.MustEqual(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
# Description

<!-- Summarize your PR. Give some context and introduction to the changes -->

Fixes an issue in our completion injection where flag values (with equal sign) was not accounted for.

The issue was that we had some hacks that required us to do some manual completion filtering, so when the user completes `--namespace` then we filtered the results to only values with the prefix `--namespace`. However, the bug was that we also did this for flag values like `--namespace=kube` where we'd then filter the output for the prefix `--namespace=kube` but we should've filtered the output by just `kube`.

As a demo, completing `--namespace` results in the completion of the flag:

```console
$ \kubectl __complete --namespace
--namespace     If present, the namespace scope for this CLI request
:4
Completion ended with directive: ShellCompDirectiveNoFileComp
```

but completing `--namespace=` results in the completion of the flag values:

```console
$ \kubectl __complete --namespace=
cert-manager
default
kube-node-lease
kube-public
kube-system
mastodon
metrics
nextcloud
traefik
:4
Completion ended with directive: ShellCompDirectiveNoFileComp
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (fixes an issue)

## Changes

<!-- What was changed, technically? -->

- Fixed completion not working correctly

## Motivation

<!-- Why you think we should change it? -->

Bug.

## Related issue (if exists)

<!-- remove if no related issue -->

Closes #207
