### PR TITLE
Colorize `kubectl apply --server-side`

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -193,6 +193,10 @@
           "$ref": "#/$defs/color",
           "description": "used on \"deployment.apps/quux unchanged\""
         },
+        "serverside": {
+          "$ref": "#/$defs/color",
+          "description": "used on \"deployment.apps/quux serverside-applied\""
+        },
         "dryRun": {
           "$ref": "#/$defs/color",
           "description": "used on \"(dry run)\" and \"(server dry run)\""

--- a/config/theme.go
+++ b/config/theme.go
@@ -410,6 +410,7 @@ type ThemeApply struct {
 	Created    color.Color `defaultFrom:"theme.base.success"` // used on "deployment.apps/foo created"
 	Configured color.Color `defaultFrom:"theme.base.warning"` // used on "deployment.apps/bar configured"
 	Unchanged  color.Color `defaultFrom:"theme.base.primary"` // used on "deployment.apps/quux unchanged"
+	Serverside color.Color `defaultFrom:"theme.base.warning"` // used on "deployment.apps/quux serverside-applied"
 
 	DryRun   color.Color `defaultFrom:"theme.base.secondary"` // used on "(dry run)" and "(server dry run)"
 	Fallback color.Color `defaultFrom:"theme.base.success"`   // used when outputs unknown format

--- a/printer/kubectl_output_colored_printer.go
+++ b/printer/kubectl_output_colored_printer.go
@@ -159,9 +159,10 @@ func (p *KubectlOutputColoredPrinter) getPrinter() Printer {
 				DryRunColor:   p.Theme.Apply.DryRun,
 				FallbackColor: p.Theme.Apply.Fallback,
 				VerbColor: map[string]color.Color{
-					"created":    p.Theme.Apply.Created,
-					"configured": p.Theme.Apply.Configured,
-					"unchanged":  p.Theme.Apply.Unchanged,
+					"created":            p.Theme.Apply.Created,
+					"configured":         p.Theme.Apply.Configured,
+					"unchanged":          p.Theme.Apply.Unchanged,
+					"serverside-applied": p.Theme.Apply.Serverside,
 				},
 			}
 

--- a/test/corpus/kubectl_apply.txt
+++ b/test/corpus/kubectl_apply.txt
@@ -137,3 +137,19 @@ $ kubectl apply -f deploy.yaml -o json
         }
     }
 }
+
+================================================================================
+$ kubectl apply -f traefik.yml --server-side --force-conflicts
+================================================================================
+
+customresourcedefinition.apiextensions.k8s.io/gatewayclasses.gateway.networking.k8s.io serverside-applied
+customresourcedefinition.apiextensions.k8s.io/gateways.gateway.networking.k8s.io serverside-applied
+customresourcedefinition.apiextensions.k8s.io/grpcroutes.gateway.networking.k8s.io serverside-applied
+customresourcedefinition.apiextensions.k8s.io/httproutes.gateway.networking.k8s.io serverside-applied
+
+--------------------------------------------------------------------------------
+
+customresourcedefinition.apiextensions.k8s.io/gatewayclasses.gateway.networking.k8s.io [33mserverside-applied[0m
+customresourcedefinition.apiextensions.k8s.io/gateways.gateway.networking.k8s.io [33mserverside-applied[0m
+customresourcedefinition.apiextensions.k8s.io/grpcroutes.gateway.networking.k8s.io [33mserverside-applied[0m
+customresourcedefinition.apiextensions.k8s.io/httproutes.gateway.networking.k8s.io [33mserverside-applied[0m


### PR DESCRIPTION
# Description

Adds missing colorization on `kubectl apply --server-side`

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (added functionality)
- [x] Requires further documentation updates (on https://kubecolor.github.io/)

## Changes

<!-- What was changed, technically? -->

- Added coloring of verb `serverside-applied`

## Motivation

<!-- Why you think we should change it? -->

More colors. It was just green before.

## Related issue (if exists)

<!-- remove if no related issue -->

Closes #194
