### PR TITLE
Update to Go 1.23.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.23.4 AS build
+FROM docker.io/library/golang:1.23.6 AS build
 
 WORKDIR /go/src/kubecolor
 COPY go.mod go.sum .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubecolor/kubecolor
 
-go 1.23.4
+go 1.23.6
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0


### PR DESCRIPTION
# Description

Updates Go for the sake of resolving vulnerabilities:

- "Timing sidechannel for P-256 on ppc64le in crypto/internal/nistec" https://pkg.go.dev/vuln/GO-2025-3447
- "Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509" https://pkg.go.dev/vuln/GO-2025-3373

These vulnerabilities originate from `strings.Replacer.Replace`, which we use. But we don't do any auth or anything security related so these vulnerabilities don't really apply to us.

Let's still update though just to silence the security alerts.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (doesn't directly affect users, e.g refactoring or CI/CD changes)

## Changes

<!-- What was changed, technically? -->

- Changed Go version in go.mod & Dockerfile

## Motivation

Stay up-to-date & resolve govulncheck alert

## Related issue (if exists)

<!-- remove if no related issue -->

Closes #213
