### PR TITLE
Update Go to 1.24.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.23.6 AS build
+FROM docker.io/library/golang:1.24.2 AS build
 
 WORKDIR /go/src/kubecolor
 COPY go.mod go.sum .

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/kubecolor/kubecolor
 
-go 1.23.6
-toolchain go1.24.1
+go 1.24.2
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0

--- a/kubectl/subcommand_test.go
+++ b/kubectl/subcommand_test.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/kubecolor/kubecolor/testutil"
 )
 
@@ -96,10 +95,7 @@ func TestInspectSubcommandInfo(t *testing.T) {
 		t.Run(tc.args, func(t *testing.T) {
 			t.Parallel()
 			s := InspectSubcommandInfo(strings.Fields(tc.args), pluginHandler)
-
-			if diff := cmp.Diff(s, tc.expected); diff != "" {
-				t.Errorf(diff)
-			}
+			testutil.Equal(t, s, tc.expected)
 		})
 	}
 }


### PR DESCRIPTION
# Description

Updated Go to resolve vulnerabilities:

```console
$ govulncheck ./...
govulncheck: loading packages: 
There are errors with the provided package patterns:

/home/runner/go/pkg/mod/golang.org/x/sys@v0.29.0/unix/vgetrandom_linux.go:7:9: file requires newer Go version go1.24 (application built with go1.23)

For details on package patterns, see https://pkg.go.dev/cmd/go#hdr-Package_lists_and_patterns.
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (doesn't directly affect users, e.g refactoring or CI/CD changes)

## Changes

<!-- What was changed, technically? -->

- Changed version of Go in `go.mod` & `Dockerfile`

## Motivation

Keep it up-to-date, and to resolve vulnerability

## Related issue (if exists)

Closes #226
