### PR TITLE
Use draft releases when releasing new versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,25 @@
 name: goreleaser
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    # Only run when a release is created, but not when it has been published.
+    #
+    # Release process:
+    # 1. you create a draft release
+    # 2. this "release.yml" workflow gets triggered
+    # 3. goreleaser builds binaries and pushes them as release artifacts
+    # 4. goreleaser publishes the release (on GitHub, Homebrew, Docker, etc.)
+    #
+    # This allows us to have build errors on step 3. without us having to
+    # roll back a release or artificially bump the version just because of
+    # a CI/CD issue.
+    types: [created]
+
+permissions:
+  # Required to upload binaries to GitHub releases
+  contents: write
+  # Required to push Docker image to ghcr.io/kubecolor/kubecolor
+  packages: write
 
 jobs:
   goreleaser:
@@ -21,13 +37,13 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GLOBAL_GITHUB_TOKEN: ${{ secrets.GLOBAL_GITHUB_TOKEN }}
           FORCE_COLOR: "true"
+
   homebrew:
     name: Bump Homebrew formula
     # Skip this job in case of git pushes to prerelease tags

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,50 +9,62 @@ before:
     - make testshort
 
 builds:
-- id: kubecolor
-  main: ./main.go
-  binary: kubecolor
-  env:
-    - CGO_ENABLED=0
-  ldflags:
-    - -s -w
-    - -X main.Version={{.Version}}
-  goos:
-    - windows
-    - darwin
-    - linux
-  goarch:
-    - arm64
-    - amd64
-    - ppc64le
+  - id: kubecolor
+    main: ./main.go
+    binary: kubecolor
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X main.Version={{.Version}}
+    goos:
+      - windows
+      - darwin
+      - linux
+    goarch:
+      - arm64
+      - amd64
+      - ppc64le
 
 archives:
-- builds:
-  - kubecolor
-  format: tar.gz
-  format_overrides:
-    - goos: windows
-      format: zip
+  - builds:
+      - kubecolor
+    format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
 
 brews:
-- name: kubecolor
-  repository:
-    owner: kubecolor
-    name: homebrew-tap
-    token: "{{ .Env.GLOBAL_GITHUB_TOKEN }}"
-  homepage: "https://github.com/kubecolor/kubecolor"
-  description: "Colorize your kubectl output"
-  license: "MIT"
-  directory: Formula
-  install: |
-    bin.install "kubecolor"
+  - name: kubecolor
+    repository:
+      owner: kubecolor
+      name: homebrew-tap
+      token: "{{ .Env.GLOBAL_GITHUB_TOKEN }}"
+    homepage: "https://github.com/kubecolor/kubecolor"
+    description: "Colorize your kubectl output"
+    license: "MIT"
+    directory: Formula
+    install: |
+      bin.install "kubecolor"
 
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 
 changelog:
   sort: asc
   filters:
     exclude:
-    - '^docs:'
-    - '^test:'
+      - "^docs:"
+      - "^test:"
+
+release:
+  # Our "release.yml" workflow triggers when a release is created,
+  # even as a draft, so that goreleaser can populate it later
+  # and finalize the release.
+  #
+  # This allows us to do some hotfixing of our release pipelines
+  # in case there were some bugs, as in the case of failure the
+  # GitHub release is never published and the Git tag is never pushed.
+  use_existing_draft: true
+
+  mode: keep-existing


### PR DESCRIPTION
# Description

Changes our `release.yml` workflow to trigger when a release is created (as a draft), and let goreleaser populate the release with binaries/archives and then publish the release for us.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (doesn't directly affect users, e.g refactoring or CI/CD changes)

## Changes

<!-- What was changed, technically? -->

- Changed goreleaser to try reuse a draft release if it finds one
- Changed `release.yml` workflow to trigger on draft release instead of on new tag

## Motivation

A big pain point with automated continuous delivery is when the pipelines break.

Imagine, with the old workflow:

1. you create a tag v0.5.0
2. the goreleaser pipeline failed
3. you push a fix to the goreleaser pipeline
4. you have to create a new tag, e.g v0.5.1
5. maybe repeat step 2-4 a couple of times, so you end up at version v0.5.7
6. all of our users get super confused why we just jumped from v0.5.0 to v0.5.7

This is super annoying and has happened to us before (like with v0.3.0 where we tried recreating the tag instead of bumping the version).

Instead of all that, this PR sets a new process where:

1. you create a **draft** release v0.5.0 (draft releases are not visible to the users and does not create a Git tag until published)
2. the goreleaser pipeline failed
3. you push a fix to the goreleaser pipeline
4. you recreate the **draft** release as v0.5.0 (which is fine because it was never public to begin with)
5. maybe repeat step 2-4 a couple of times, but that's OK. Still at v0.5.0
6. all of our users are super happy because we seemingly release perfect releases every time

or, at least that's how I think this works. I've never tried it :)

Question is, how do we make sure we always follow this workflow? Are the comments in `.goreleaser.yml` & `release.yml` enough? Or should we have more documentation on this?

I'll first be able to test this on the next release of kubecolor.
