### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @kubecolor/maintainers
+* @kubecolor/maintainers @applejag

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @kubecolor/maintainers


### PR DESCRIPTION
# Description

Adds a CODEOWNERS file

## Type of change

- [x] Chore (doesn't directly affect users, e.g refactoring or CI/CD changes)

## Changes

<!-- What was changed, technically? -->

- Added `.github/CODEOWNERS` pointing to <https://github.com/orgs/kubecolor/teams/maintainers>

## Motivation

The CODEOWNERS file automatically adds the reviewers, which is useful. Especially for when we get external contributions
