### PR TITLE
Proposal: Support colorizing arg based subcommands

### DIFF
--- a/kubectl/subcommand.go
+++ b/kubectl/subcommand.go
@@ -174,6 +174,7 @@ func InspectSubcommandArgs(args []string, info *SubcommandInfo) {
 	i := 0
 	for i < len(args) {
 		if args[i] == "--" {
+			info.SubcommandArgs = append(info.SubcommandArgs, args[i+1:]...)
 			break
 		}
 

--- a/kubectl/subcommand_test.go
+++ b/kubectl/subcommand_test.go
@@ -13,73 +13,80 @@ func TestInspectSubcommandInfo(t *testing.T) {
 		args     string
 		expected *SubcommandInfo
 	}{
-		{"get pods", &SubcommandInfo{Subcommand: Get}},
-		{"get pod", &SubcommandInfo{Subcommand: Get}},
-		{"get po", &SubcommandInfo{Subcommand: Get}},
+		{"get pods", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pods"}}},
+		{"get pod", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}}},
+		{"get po", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"po"}}},
 
-		{"get pod -o wide", &SubcommandInfo{Subcommand: Get, Output: OutputWide}},
-		{"get pod -o=wide", &SubcommandInfo{Subcommand: Get, Output: OutputWide}},
-		{"get pod -owide", &SubcommandInfo{Subcommand: Get, Output: OutputWide}},
+		{"get pod -o wide", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Output: OutputWide}},
+		{"get pod -o=wide", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Output: OutputWide}},
+		{"get pod -owide", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Output: OutputWide}},
 
-		{"get pod -o json", &SubcommandInfo{Subcommand: Get, Output: OutputJSON}},
-		{"get pod -o=json", &SubcommandInfo{Subcommand: Get, Output: OutputJSON}},
-		{"get pod -ojson", &SubcommandInfo{Subcommand: Get, Output: OutputJSON}},
+		{"get pod -o json", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Output: OutputJSON}},
+		{"get pod -o=json", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Output: OutputJSON}},
+		{"get pod -ojson", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Output: OutputJSON}},
 
-		{"get pod -o yaml", &SubcommandInfo{Subcommand: Get, Output: OutputYAML}},
-		{"get pod -o=yaml", &SubcommandInfo{Subcommand: Get, Output: OutputYAML}},
-		{"get pod -oyaml", &SubcommandInfo{Subcommand: Get, Output: OutputYAML}},
+		{"get pod -o yaml", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Output: OutputYAML}},
+		{"get pod -o=yaml", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Output: OutputYAML}},
+		{"get pod -oyaml", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Output: OutputYAML}},
 
-		{"get pod --output json", &SubcommandInfo{Subcommand: Get, Output: OutputJSON}},
-		{"get pod --output=json", &SubcommandInfo{Subcommand: Get, Output: OutputJSON}},
-		{"get pod --output yaml", &SubcommandInfo{Subcommand: Get, Output: OutputYAML}},
-		{"get pod --output=yaml", &SubcommandInfo{Subcommand: Get, Output: OutputYAML}},
-		{"get pod --output wide", &SubcommandInfo{Subcommand: Get, Output: OutputWide}},
-		{"get pod --output=wide", &SubcommandInfo{Subcommand: Get, Output: OutputWide}},
+		{"get pod --output json", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Output: OutputJSON}},
+		{"get pod --output=json", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Output: OutputJSON}},
+		{"get pod --output yaml", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Output: OutputYAML}},
+		{"get pod --output=yaml", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Output: OutputYAML}},
+		{"get pod --output wide", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Output: OutputWide}},
+		{"get pod --output=wide", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Output: OutputWide}},
 
-		{"get pod --no-headers", &SubcommandInfo{Subcommand: Get, NoHeader: true}},
-		{"get pod -w", &SubcommandInfo{Subcommand: Get, Watch: true}},
-		{"get pod --watch", &SubcommandInfo{Subcommand: Get, Watch: true}},
-		{"get pod -h", &SubcommandInfo{Subcommand: Get, Help: true}},
-		{"get pod --help", &SubcommandInfo{Subcommand: Get, Help: true}},
+		{"get pod --no-headers", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, NoHeader: true}},
+		{"get pod -w", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Watch: true}},
+		{"get pod --watch", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Watch: true}},
+		{"get pod -h", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Help: true}},
+		{"get pod --help", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Help: true}},
 
-		{"get pod --output custom-columns=NAME:.metadata.name", &SubcommandInfo{Subcommand: Get, Output: OutputCustomColumns}},
-		{"get pod --output=custom-columns=NAME:.metadata.name", &SubcommandInfo{Subcommand: Get, Output: OutputCustomColumns}},
-		{"get pod --output custom-columns-file=./foo.txt", &SubcommandInfo{Subcommand: Get, Output: OutputCustomColumnsFile}},
-		{"get pod --output=custom-columns-file=./foo.txt", &SubcommandInfo{Subcommand: Get, Output: OutputCustomColumnsFile}},
+		{"get pod --output custom-columns=NAME:.metadata.name", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Output: OutputCustomColumns}},
+		{"get pod --output=custom-columns=NAME:.metadata.name", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Output: OutputCustomColumns}},
+		{"get pod --output custom-columns-file=./foo.txt", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Output: OutputCustomColumnsFile}},
+		{"get pod --output=custom-columns-file=./foo.txt", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Output: OutputCustomColumnsFile}},
 
-		{"get pod --output name", &SubcommandInfo{Subcommand: Get, Output: OutputOther}},
-		{"get pod --output=name", &SubcommandInfo{Subcommand: Get, Output: OutputOther}},
-		{"get pod --output jsonpath=...", &SubcommandInfo{Subcommand: Get, Output: OutputOther}},
-		{"get pod --output=jsonpath=...", &SubcommandInfo{Subcommand: Get, Output: OutputOther}},
+		{"get pod --output name", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Output: OutputOther}},
+		{"get pod --output=name", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Output: OutputOther}},
+		{"get pod --output jsonpath=...", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Output: OutputOther}},
+		{"get pod --output=jsonpath=...", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pod"}, Output: OutputOther}},
 
-		{"describe pod pod-aaa", &SubcommandInfo{Subcommand: Describe}},
-		{"top pod", &SubcommandInfo{Subcommand: Top}},
-		{"top pods", &SubcommandInfo{Subcommand: Top}},
+		{"describe pod pod-aaa", &SubcommandInfo{Subcommand: Describe, SubcommandArgs: []string{"pod", "pod-aaa"}}},
+		{"top pod", &SubcommandInfo{Subcommand: Top, SubcommandArgs: []string{"pod"}}},
+		{"top pods", &SubcommandInfo{Subcommand: Top, SubcommandArgs: []string{"pods"}}},
+
+		{"auth can-i", &SubcommandInfo{Subcommand: Auth, SubcommandArgs: []string{"can-i"}}},
+		{"auth whoami", &SubcommandInfo{Subcommand: Auth, SubcommandArgs: []string{"whoami"}}},
+		{"config get-contexts", &SubcommandInfo{Subcommand: Config, SubcommandArgs: []string{"get-contexts"}}},
+		{"config current-context", &SubcommandInfo{Subcommand: Config, SubcommandArgs: []string{"current-context"}}},
+		{"config view --minify", &SubcommandInfo{Subcommand: Config, SubcommandArgs: []string{"view"}}},
 
 		{"api-versions", &SubcommandInfo{Subcommand: APIVersions}},
 
-		{"explain pod", &SubcommandInfo{Subcommand: Explain}},
-		{"explain pod --recursive=true", &SubcommandInfo{Subcommand: Explain, Recursive: true}},
-		{"explain pod --recursive", &SubcommandInfo{Subcommand: Explain, Recursive: true}},
+		{"explain pod", &SubcommandInfo{Subcommand: Explain, SubcommandArgs: []string{"pod"}}},
+		{"explain pod --recursive=true", &SubcommandInfo{Subcommand: Explain, SubcommandArgs: []string{"pod"}, Recursive: true}},
+		{"explain pod --recursive", &SubcommandInfo{Subcommand: Explain, SubcommandArgs: []string{"pod"}, Recursive: true}},
 
 		{"version", &SubcommandInfo{Subcommand: Version}},
 		{"version --client", &SubcommandInfo{Subcommand: Version, Client: true}},
 		{"version -o json", &SubcommandInfo{Subcommand: Version, Output: OutputJSON}},
 		{"version -o yaml", &SubcommandInfo{Subcommand: Version, Output: OutputYAML}},
+		{"auth can-i --list", &SubcommandInfo{Subcommand: Auth, SubcommandArgs: []string{"can-i"}, List: true}},
 
 		{"apply", &SubcommandInfo{Subcommand: Apply}},
 
 		{"rsh", &SubcommandInfo{Subcommand: Rsh}},
 
 		{"testplugin", &SubcommandInfo{Subcommand: KubectlPlugin}},
-		{"testplugin with args", &SubcommandInfo{Subcommand: KubectlPlugin}},
-		{"my-plugin with multiple words", &SubcommandInfo{Subcommand: KubectlPlugin}},
+		{"testplugin with args", &SubcommandInfo{Subcommand: KubectlPlugin, SubcommandArgs: []string{"with", "args"}}},
+		{"my-plugin with multiple words", &SubcommandInfo{Subcommand: KubectlPlugin, SubcommandArgs: []string{"with", "multiple", "words"}}},
 		// Args are not allowed in-between
 		{"my-plugin --hello with multiple words", &SubcommandInfo{Subcommand: Unknown, Help: true}},
 		// No plugin found, so assume it is help
 		{"my-non-existing-plugin", &SubcommandInfo{Subcommand: Unknown, Help: true}},
 
-		{"get pods -- --help", &SubcommandInfo{Subcommand: Get}},
+		{"get pods -- --help", &SubcommandInfo{Subcommand: Get, SubcommandArgs: []string{"pods"}}},
 		{"-- --help", &SubcommandInfo{Subcommand: Unknown, Help: true}},
 
 		{"", &SubcommandInfo{Subcommand: Unknown, Help: true}},
@@ -106,12 +113,14 @@ func TestParseArgFlag(t *testing.T) {
 		args      []string
 		wantFlag  string
 		wantValue string
+		wantSkip  int
 	}{
 		{
 			name:      "empty",
 			args:      nil,
 			wantFlag:  "",
 			wantValue: "",
+			wantSkip:  0,
 		},
 
 		{
@@ -119,24 +128,28 @@ func TestParseArgFlag(t *testing.T) {
 			args:      []string{"--output"},
 			wantFlag:  "--output",
 			wantValue: "",
+			wantSkip:  1,
 		},
 		{
 			name:      "long 2 args",
 			args:      []string{"--output", "wide"},
 			wantFlag:  "--output",
 			wantValue: "wide",
+			wantSkip:  2,
 		},
 		{
 			name:      "long equals",
 			args:      []string{"--output=wide"},
 			wantFlag:  "--output",
 			wantValue: "wide",
+			wantSkip:  1,
 		},
 		{
 			name:      "long double equals",
 			args:      []string{"--output=wide"},
 			wantFlag:  "--output",
 			wantValue: "wide",
+			wantSkip:  1,
 		},
 
 		{
@@ -144,38 +157,44 @@ func TestParseArgFlag(t *testing.T) {
 			args:      []string{"-o"},
 			wantFlag:  "-o",
 			wantValue: "",
+			wantSkip:  1,
 		},
 		{
 			name:      "short 2 args",
 			args:      []string{"-o", "wide"},
 			wantFlag:  "-o",
 			wantValue: "wide",
+			wantSkip:  2,
 		},
 		{
 			name:      "short smushed",
 			args:      []string{"-owide"},
 			wantFlag:  "-o",
 			wantValue: "wide",
+			wantSkip:  1,
 		},
 		{
 			name:      "short equals",
 			args:      []string{"-o=wide"},
 			wantFlag:  "-o",
 			wantValue: "wide",
+			wantSkip:  1,
 		},
 		{
 			name:      "short double equals",
 			args:      []string{"-o==wide"},
 			wantFlag:  "-o",
 			wantValue: "=wide",
+			wantSkip:  1,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			flag, value := parseArgFlag(tc.args)
+			flag, value, skip := parseArgFlag(tc.args)
 			testutil.Equalf(t, tc.wantFlag, flag, "flag of %v", tc.args)
 			testutil.Equalf(t, tc.wantValue, value, "value of %v", tc.args)
+			testutil.Equalf(t, tc.wantSkip, skip, "skip of %v", tc.args)
 		})
 	}
 }

--- a/printer/kubectl_auth.go
+++ b/printer/kubectl_auth.go
@@ -1,0 +1,53 @@
+package printer
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+
+	"github.com/kubecolor/kubecolor/config"
+)
+
+// AuthPrinter is used in "kubectl auth" output
+type AuthPrinter struct {
+	Theme *config.Theme
+
+	Args []string
+	List bool
+}
+
+// ensures it implements the interface
+var _ Printer = &AuthPrinter{}
+
+func (p *AuthPrinter) Print(r io.Reader, w io.Writer) {
+	arg := ""
+	if len(p.Args) > 0 {
+		arg = p.Args[0]
+	}
+
+	switch arg {
+	case "can-i":
+		p.printCanI(r, w)
+	default:
+		io.Copy(w, r)
+	}
+}
+
+func (p *AuthPrinter) printCanI(r io.Reader, w io.Writer) {
+	if p.List {
+		NewTablePrinter(true, p.Theme, nil).Print(r, w)
+	} else {
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			line := scanner.Text()
+			switch line {
+			case "yes":
+				fmt.Fprintf(w, "%s\n", p.Theme.Base.Success.Render(line))
+			case "no":
+				fmt.Fprintf(w, "%s\n", p.Theme.Base.Warning.Render(line))
+			default:
+				fmt.Fprintf(w, "%s\n", line)
+			}
+		}
+	}
+}

--- a/printer/kubectl_output_colored_printer.go
+++ b/printer/kubectl_output_colored_printer.go
@@ -246,6 +246,13 @@ func (p *KubectlOutputColoredPrinter) getPrinter() Printer {
 				},
 			}
 		}
+
+	case kubectl.Auth:
+		return &AuthPrinter{
+			Theme: p.Theme,
+			List:  p.SubcommandInfo.List,
+			Args:  p.SubcommandInfo.SubcommandArgs,
+		}
 	}
 
 	return &SingleColoredPrinter{Color: p.Theme.Default}

--- a/printer/util.go
+++ b/printer/util.go
@@ -230,12 +230,16 @@ func findIndent(line string) int {
 //
 // Commonly found in "kubectl get" output
 func isAllUpper(s string) bool {
+	atLeastOneLetter := false
 	for _, r := range s {
-		if unicode.IsLetter(r) && !unicode.IsUpper(r) {
-			return false
+		if unicode.IsLetter(r) {
+			atLeastOneLetter = true
+			if !unicode.IsUpper(r) {
+				return false
+			}
 		}
 	}
-	return true
+	return atLeastOneLetter
 }
 
 // isOnlySymbols is used to identity header underline like this:
@@ -247,7 +251,7 @@ func isAllUpper(s string) bool {
 func isOnlySymbols(s string) bool {
 	anyPuncts := false
 	for _, r := range s {
-		if unicode.IsLetter(r) || unicode.IsNumber(r) {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) || r == '[' || r == ']' {
 			return false
 		}
 		if unicode.IsPunct(r) {


### PR DESCRIPTION
# Description

Hi @applejag,

As you mentioned in #88, kubecolor currently doesn't support colorizing output for certain subcommands—particularly when those subcommands have their own subcommands (i.e., nested subcommands, or more generally, subcommands that take arguments and produce different outputs based on those arguments):

> One thing that's special about this one is that it has different coloring rules for subcommands of a subcommand, which is not yet supported in kubecolor.

I'd like to propose an approach and open the discussion for possible alternatives. In this PR, I’ve experimented with parsing the arguments of a subcommand (which I think is a clearer way to describe it than "subcommand of a subcommand") and passing them to the printer. This allows the printer to determine how to colorize the output based on those specific arguments.

As a proof of concept, I’ve added support for the `auth can-i` subcommand. This demonstrates how we could also support other subcommands that take additional arguments, such as `config`.

Looking forward to your feedback or any suggestions you might have for a cleaner or more extensible approach!



## Type of change

- [x] New feature (added functionality)
- [ ] Requires further documentation updates (on https://kubecolor.github.io/)



