### PR TITLE
Fix excess base64 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,8 +131,8 @@ jobs:
           PACKAGES_GPG_PUBKEY: ${{ secrets.PACKAGES_GPG_PUBKEY }}
           PACKAGES_GPG_KEY: ${{ secrets.PACKAGES_GPG_KEY }}
         run: |
-          base64 -d <<<"$PACKAGES_GPG_PUBKEY" | gpg --import --no-tty --batch --yes
-          base64 -d <<<"$PACKAGES_GPG_KEY" | gpg --import --no-tty --batch --yes
+          gpg --import --no-tty --batch --yes <<<"$PACKAGES_GPG_PUBKEY"
+          gpg --import --no-tty --batch --yes <<<"$PACKAGES_GPG_KEY"
 
       - name: Prepare release assets
         run: |


### PR DESCRIPTION
# Description

Fixes the workflow.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (fixes an issue)

## Changes

<!-- What was changed, technically? -->

- Removes the `base64 -d`

## Motivation

I copy-pasted a lot of these workflow steps from the GitHub CLI repo's workflow. They store their GPG key in GitHub secrets as base64-encoded, while I opted for just storing them as-is using PEM-encoding. Therefore, no `base64 -d` is needed.

