### PR TITLE
Fix upload assets to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,6 +169,8 @@ jobs:
         run: assets/packaging/version.sh
 
       - name: Upload assets to release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           assets/packaging/gh-label-assets.sh dist/kubecolor_* \
             | xargs gh release upload "${{ inputs.tag-name }}" --clobber --


### PR DESCRIPTION
# Description

Fix

## Type of change

- [x] Bug fix (fixes an issue)

## Changes

- Fixed missing `GH_TOKEN` env var for the `gh` CLI in release.yml workflow

## Motivation

Failed: <https://github.com/kubecolor/kubecolor/actions/runs/14618868576/job/41013589477>

