### PR TITLE
Add missing error status colorizing

### DIFF
--- a/printer/util.go
+++ b/printer/util.go
@@ -143,13 +143,17 @@ func colorSingleStatus(status string, theme *config.Theme) (string, bool) {
 
 		// some other status
 		"ContainerStatusUnknown",
+		"ContainerCannotRun",
 		"CrashLoopBackOff",
+		"DeadlineExceeded",
 		"ImagePullBackOff",
 		"Evicted",
 		"FailedScheduling",
 		"Error",
 		"ErrImagePull",
 		"OOMKilled",
+		"RunContainerError",
+		"StartError",
 		// PVC status
 		"Lost":
 		return theme.Status.Error.Render(status), true


### PR DESCRIPTION
# Description

I got curious after seeing issue #254 and I implemented colorizing for missing error status.

I didn't manage to get the `StartError` status mentioned but I accidentally got `ContainerCannotRun` which wasn't implemented either.

I also added `DeadlineExceeded` and `RunContainerError` as I found these mentioned in other repos. I haven't been able to find a documented list with all the possible reasons as it seems to depend heavily on the CRI used.

Before:
<img width="670" alt="image" src="https://github.com/user-attachments/assets/0fcf7a58-5a02-4841-88b5-6d4b34cbada3" />

After:
<img width="670" alt="image" src="https://github.com/user-attachments/assets/e4960e63-e76c-4e52-8537-cf675d7dbb42" />

For anyone interested, I got this error by creating a pod with a fake command like this:

```bash
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: Pod
metadata:
  name: test
spec:
  containers:
  - name: busybox
    image: busybox:latest
    command: ["/bin/this-command-does-not-exist"]
  restartPolicy: Never
EOF
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (fixes an issue)

## Changes

<!-- What was changed, technically? -->

- Added new error status

## Motivation

<!-- Why you think we should change it? -->
More accurate colorizing.

## Related issue (if exists)

<!-- remove if no related issue -->

Closes #254 
