### PR TITLE
Update Go v1.24.0 -> v1.24.5 & mapstructure v2.2.1 -> v2.4.0 to fix vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.24.2 AS build
+FROM docker.io/library/golang:1.24.5 AS build
 
 WORKDIR /go/src/kubecolor
 COPY go.mod go.sum .

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
+	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubecolor/kubecolor
 
-go 1.24.2
+go 1.24.5
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
-github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
+github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/gookit/color v1.5.4 h1:FZmqs7XOyGgCAxmWyPslpiok1k05wmY3SJTytgvYFs0=


### PR DESCRIPTION
# Description

Updates mapstructure & Go to fix vulnerabilities reported by govulncheck:

```console
$ govulncheck ./...
=== Symbol Results ===

Vulnerability #1: GO-2025-3787
    May leak sensitive information in logs when processing malformed data in
    github.com/go-viper/mapstructure
  More info: https://pkg.go.dev/vuln/GO-2025-3787
  Module: github.com/go-viper/mapstructure/v2
    Found in: github.com/go-viper/mapstructure/v2@v2.2.1
    Fixed in: github.com/go-viper/mapstructure/v2@v2.3.0
    Example traces found:
      #1: config/config.go:94:23: config.Unmarshal calls viper.Viper.Unmarshal, which eventually calls errors.As
      #2: config/config.go:94:23: config.Unmarshal calls viper.Viper.Unmarshal, which eventually calls errors.Join
      #3: config/config.go:94:23: config.Unmarshal calls viper.Viper.Unmarshal, which eventually calls errors.New
      #4: internal/cmd/configdoc/main.go:11:2: configdoc.init calls viper.init, which eventually calls errors.init
      #5: config/config.go:94:23: config.Unmarshal calls viper.Viper.Unmarshal, which eventually calls mapstructure.ComposeDecodeHookFunc
      #6: config/config.go:94:23: config.Unmarshal calls viper.Viper.Unmarshal, which eventually calls mapstructure.Decoder.Decode
      #7: config/config.go:94:23: config.Unmarshal calls viper.Viper.Unmarshal, which eventually calls mapstructure.NewDecoder
      #8: config/config.go:94:23: config.Unmarshal calls viper.Viper.Unmarshal, which eventually calls mapstructure.StringToTimeDurationHookFunc
      #9: internal/cmd/configdoc/main.go:11:2: configdoc.init calls viper.init, which calls mapstructure.init

Vulnerability #2: GO-2025-3750
    Inconsistent handling of O_CREATE|O_EXCL on Unix and Windows in os in
    syscall
  More info: https://pkg.go.dev/vuln/GO-2025-3750
  Standard library
    Found in: syscall@go1.24.2
    Fixed in: syscall@go1.24.4
    Platforms: windows
    Example traces found:
      #1: internal/cmd/configschema/main.go:123:22: configschema.main calls os.Create
      #2: internal/testcorpus/parse.go:30:25: testcorpus.ParseGlobFS calls fs.Glob, which eventually calls os.File.ReadDir
      #3: internal/cmd/configschema/main.go:45:17: configschema.main calls jsonschema.Reflector.AddGoComments, which eventually calls os.File.Readdirnames
      #4: internal/testcorpus/run.go:171:46: testcorpus.createColoredDiff calls span.URIFromPath, which eventually calls os.Getwd
      #5: internal/cmd/configschema/main.go:45:17: configschema.main calls jsonschema.Reflector.AddGoComments, which eventually calls os.Lstat
      #6: testutil/env.go:4:2: testutil.init calls os.init, which calls os.NewFile
      #7: command/runner.go:218:22: command.getStdinOverrideReader calls os.Open
      #8: command/runner.go:207:21: command.execWithReaders calls exec.Cmd.Start, which eventually calls os.OpenFile
      #9: command/runner.go:285:22: command.runPager calls os.Pipe
      #10: internal/cmd/configschema/main.go:45:17: configschema.main calls jsonschema.Reflector.AddGoComments, which eventually calls os.ReadDir
      #11: internal/cmd/imagegen/main.go:87:27: imagegen.main calls os.ReadFile
      #12: command/runner.go:207:21: command.execWithReaders calls exec.Cmd.Start, which calls os.StartProcess
      #13: kubectl/plugin.go:86:29: kubectl.DefaultPluginHandler.Lookup calls exec.LookPath, which eventually calls os.Stat
      #14: internal/testcorpus/update.go:59:24: testcorpus.updateFile calls os.WriteFile
      #15: internal/testcorpus/parse.go:59:24: testcorpus.ParseFileFS calls os.dirFS.Open
      #16: internal/testcorpus/parse.go:30:25: testcorpus.ParseGlobFS calls fs.Glob, which eventually calls os.dirFS.ReadDir
      #17: internal/testcorpus/parse.go:37:23: testcorpus.ParseGlobFS calls fs.Stat, which calls os.dirFS.Stat
      #18: internal/cmd/configschema/main.go:45:17: configschema.main calls jsonschema.Reflector.AddGoComments, which eventually calls os.unixDirent.Info
      #19: internal/cmd/configschema/main.go:123:22: configschema.main calls os.Create, which eventually calls syscall.Open

Your code is affected by 2 vulnerabilities from 1 module and the Go standard library.
This scan also found 2 vulnerabilities in packages you import and 0
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
Use '-show verbose' for more details.
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (doesn't directly affect users, e.g refactoring or CI/CD changes)

## Changes

<!-- What was changed, technically? -->

- Updated mapstructure dependency

## Motivation

These vulnerabilities doesn't really have any affects on kubecolor, but updating mapstructure will make the CI pass.

## Related issue (if exists)

<!-- remove if no related issue -->

Closes #255
