### PR TITLE
Update Go to 1.24.7 to fix vuln GO-2025-3956 / CVE-2025-47906

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.24.5 AS build
+FROM docker.io/library/golang:1.24.7 AS build
 
 WORKDIR /go/src/kubecolor
 COPY go.mod go.sum .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubecolor/kubecolor
 
-go 1.24.5
+go 1.24.7
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0


### PR DESCRIPTION
# Description

Updates Go

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (doesn't directly affect users, e.g refactoring or CI/CD changes)

## Changes

<!-- What was changed, technically? -->

- Changed Go version in go.mod from 1.24.5 to 1.24.7

## Motivation

Resolve vulnerability https://pkg.go.dev/vuln/GO-2025-3956 / CVE-2025-47906

## Related issue (if exists)

Closes #270
