### PR TITLE
Fix release workflow after actions/download-artifacts update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,9 @@ jobs:
 
       - name: Download artifacts
         uses: actions/download-artifact@v5
+        with:
+          name: artifacts
+          path: artifacts
 
       - name: Checkout documentation site
         uses: actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,6 +253,6 @@ jobs:
           context: .
           push: ${{ !inputs.dry-run }}
           tags: |
-            ghcr.io/${{ github.repository }}:${{ inputs.tag_name }}
+            ghcr.io/${{ github.repository }}:${{ inputs.tag-name }}
             ghcr.io/${{ github.repository }}:latest
-          build-args: VERSION=${{ inputs.tag_name }}
+          build-args: VERSION=${{ inputs.tag-name }}


### PR DESCRIPTION
# Description

Fixes the release pipeline

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (fixes an issue)

## Changes

<!-- What was changed, technically? -->

- Fixed [actions/download-artifact](https://github.com/actions/download-artifact) action

## Motivation

We recently updated it from v4 to v5 and this broke the release pipeline, because they changed the destination path of the downloaded artifacts.
