### PR TITLE
Fix CI/CD security to follow zizmor recommendations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,23 @@ on:
       - "main"
   pull_request:
 
+permissions: {}
+
 jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@e673c3917a1aef3c65c972347ed84ccd013ecda4 # v0.2.0
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -15,12 +31,16 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
+    permissions:
+      contents: read
     steps:
       - name: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: setup go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # 6.0.0
         with:
           go-version-file: go.mod
 
@@ -33,7 +53,7 @@ jobs:
         run: make testcover GO_TEST_CMD='gotestsum --'
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         if: matrix.os == 'ubuntu-latest'
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # required
@@ -43,15 +63,19 @@ jobs:
     name: Build docker image
     runs-on: ubuntu-latest
     if: (!contains(github.event.head_commit.message, 'skip ci'))
+    permissions:
+      contents: read
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Build, but don't push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.1
         with:
           context: .
           push: false
@@ -61,12 +85,16 @@ jobs:
 
   config-schema:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: setup go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # 6.0.0
         with:
           go-version-file: go.mod
 
@@ -78,12 +106,16 @@ jobs:
 
   corpus:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: setup go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # 6.0.0
         with:
           go-version-file: go.mod
 
@@ -98,8 +130,12 @@ jobs:
   go-version:
     runs-on: ubuntu-latest
     name: Check Go version
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Compare versions
         run: |

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -6,16 +6,23 @@ on:
       - main
   pull_request:
   schedule:
-    - cron: 0 8 * * 1  # 08:00 on mondays
+    - cron: 0 8 * * 1 # 08:00 on mondays
+
+permissions: {}
 
 jobs:
   govulncheck:
     runs-on: ubuntu-latest
     name: Run govulncheck
+    permissions:
+      contents: read
+      issues: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # 6.0.0
         with:
           go-version-file: go.mod
 
@@ -35,7 +42,7 @@ jobs:
         shell: bash
 
       - name: Create GitHub issue
-        uses: JasonEtco/create-an-issue@v2
+        uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2.9.2
         if: ${{ !cancelled() && steps.govulncheck.conclusion == 'failure' && github.event_name == 'schedule' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,5 +1,10 @@
 name: "Pull Request Labeler"
 on:
+  # Using "pull_request_target" is generally a security hole, but only
+  # if you also use "actions/checkout" in your job.
+  # Since we're not using "actions/checkout", then using "pull_request_target"
+  # is completely safe.
+  # zizmor: ignore[dangerous-triggers]
   - pull_request_target
 
 jobs:
@@ -9,4 +14,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v6
+      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,30 +31,27 @@ on:
         type: boolean
         default: false
 
-permissions:
-  # Required to upload binaries to GitHub releases
-  contents: write
-  # Required to push Docker image to ghcr.io/kubecolor/kubecolor
-  packages: write
-  # Required for signing (sigstore)
-  attestations: write
-  # Required for using GitHub IdP (when signing)
-  id-token: write
+permissions: {}
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Validate tag name format
+        env:
+          INPUT_TAG_NAME: ${{ inputs.tag-name }}
         run: |
-          if [[ ! "${{ inputs.tag-name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9.\-]+)?$ ]]; then
+          if [[ ! "$INPUT_TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9.\-]+)?$ ]]; then
             echo "Invalid tag name format. Must be in the form v1.2.3 or v1.2.3-foobar.1"
             exit 1
           fi
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Create tag
@@ -70,12 +67,13 @@ jobs:
           echo "Tagged $TAG_NAME"
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # 6.0.0
         with:
           go-version-file: go.mod
+          cache: false # prevent cache poisoning
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: "~> v2"
           # Using `--skip=publish` as we need some further processing
@@ -88,7 +86,7 @@ jobs:
           FORCE_COLOR: "true"
 
       - name: Upload goreleaser binaries as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: artifacts
           if-no-files-found: error
@@ -104,24 +102,35 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    permissions:
+      # Required to upload binaries to GitHub releases
+      contents: write
+      # Required for signing (sigstore)
+      attestations: write
+      # Required for using GitHub IdP (when signing)
+      id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # 6.0.0
         with:
           go-version-file: go.mod
+          cache: false # prevent cache poisoning
 
       - name: Download artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: artifacts
           path: artifacts
 
       - name: Checkout documentation site
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          persist-credentials: true
           repository: kubecolor/packages
           ref: gh-pages
           path: packages
@@ -174,13 +183,13 @@ jobs:
       - name: Upload assets to release
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG_NAME: ${{ inputs.tag-name }}
+          INPUT_TAG_NAME: ${{ inputs.tag-name }}
         run: |
           pushd dist
           sha256sum kubecolor_* > checksums.txt
           popd
           assets/packaging/gh-label-assets.sh dist/checksums.txt dist/kubecolor_* \
-            | xargs gh release upload "${{ inputs.tag-name }}" --clobber --
+            | xargs gh release upload "$INPUT_TAG_NAME" --clobber --
 
       - name: Publish site
         env:
@@ -189,11 +198,11 @@ jobs:
           GIT_AUTHOR_NAME: kubecolor automation
           GIT_COMMITTER_EMAIL: noreply@github.com
           GIT_COMMITTER_NAME: kubecolor automation
-          TAG_NAME: ${{ inputs.tag-name }}
+          INPUT_TAG_NAME: ${{ inputs.tag-name }}
         working-directory: ./packages
         run: |
           git add .
-          git commit -m "Add rpm and deb packages for $TAG_NAME"
+          git commit -m "Add rpm and deb packages for $INPUT_TAG_NAME"
           if [ "$DO_PUBLISH" = "true" ]; then
             git push
           else
@@ -205,8 +214,9 @@ jobs:
         if: "!inputs.dry-run"
         env:
           GH_TOKEN: ${{ github.token }}
+          INPUT_TAG_NAME: ${{ inputs.tag-name }}
         run: |
-          gh release edit "${{ inputs.tag-name }}" --draft=false
+          gh release edit "$INPUT_TAG_NAME" --draft=false
 
   homebrew:
     name: Bump Homebrew formula
@@ -217,7 +227,7 @@ jobs:
       contents: read
     needs: release
     steps:
-      - uses: mislav/bump-homebrew-formula-action@v3
+      - uses: mislav/bump-homebrew-formula-action@56a283fa15557e9abaa4bdb63b8212abc68e655c # v3.6
         with:
           formula-name: kubecolor
           formula-path: Formula/k/kubecolor.rb
@@ -234,21 +244,26 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     needs: release
+    permissions:
+      # Required to push Docker image to ghcr.io/kubecolor/kubecolor
+      packages: write
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.1
         with:
           context: .
           push: ${{ !inputs.dry-run }}


### PR DESCRIPTION
# Description

Securing our CI/CD pipeline using [Zizmor](https://zizmor.sh/)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (doesn't directly affect users, e.g refactoring or CI/CD changes)

## Changes

<!-- What was changed, technically? -->

- Pinned actions by changing from `uses: ...@v1.2.3` to `uses: ...@some-commit # @v1.2.3`
- Disable cache in release pipeline to prevent cache poisoning
- Set appropriate permissions everywhere
- Set `persist-credentials: false` on `actions/checkout` where credentials are not needed

## Motivation

Securing CI/CD is important. I found this tool in a [OpenSourceSecurity podcast episode](https://opensourcesecurity.io/2025/2025-05-securing-github-actions-william-woodruff/) and have rolled this out at work to great success.

Now I'm starting to apply it to some open source projects too.
