### PR TITLE
Remove custom homebrew tap release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,29 +218,6 @@ jobs:
         run: |
           gh release edit "$INPUT_TAG_NAME" --draft=false
 
-  homebrew:
-    name: Bump Homebrew formula
-    # Skip this job in case of git pushes to prerelease tags
-    if: "!contains(inputs.tag-name, '-') && !inputs.dry-run"
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    needs: release
-    steps:
-      - uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4.1
-        with:
-          formula-name: kubecolor
-          formula-path: Formula/k/kubecolor.rb
-          homebrew-tap: Homebrew/homebrew-core
-          base-branch: master
-          download-url: https://github.com/kubecolor/kubecolor/archive/refs/tags/${{ inputs.tag-name }}.tar.gz
-          commit-message: |
-            {{formulaName}} {{version}}
-
-            Created by https://github.com/mislav/bump-homebrew-formula-action
-        env:
-          COMMITTER_TOKEN: ${{ secrets.GLOBAL_GITHUB_TOKEN }}
-
   docker:
     runs-on: ubuntu-latest
     needs: release


### PR DESCRIPTION
# Description

Removes the broken deprecated homebrew tap releases job

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (doesn't directly affect users, e.g refactoring or CI/CD changes)

## Changes

- Removed job from release workflow

## Motivation

Kubecolor was added a while ago to the official homebrew packages https://github.com/Homebrew/homebrew-core/blob/d28a501cab5868cf359af519ff4d72c71269cab4/Formula/k/kubecolor.rb

our own homebrew tap has been deprecated since then.

But the last couple of releases to the homebrew tap (<https://github.com/kubecolor/homebrew-tap>) has even failed, with the most recent one being https://github.com/kubecolor/kubecolor/actions/runs/24310329565/job/70978951443#step:2:15

Instead of spending time getting it to work again, let's just only refer homebrew users to the official package instead.
