### PR TITLE
Adjust dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      all:
+      github-actions:
         patterns:
           - "*"
     cooldown:
@@ -18,9 +18,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    groups:
-      all:
-        patterns:
-          - "*"
     cooldown:
       default-days: 7


### PR DESCRIPTION
# Description

Changes to how Dependabot groups updates

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (doesn't directly affect users, e.g refactoring or CI/CD changes)

## Changes

- Changed grouping in `.github/dependabot.yml`

## Motivation

The grouping makes it hard to read updates in release notes.

The github-actions updates doesn't matter that much, so they can still get grouped. But let's give them a more explanatory name like `github-actions` instead of `all`, as that group name is used in the PR titles

The Go updates we want to get a clearer view of all updates, so let's skip the grouping and do 1 PR per update. That way in our release notes we have 1 list item per Go dependency update
