### PR TITLE
Update Go to v1.26.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.26.1 AS build
+FROM docker.io/library/golang:1.26.4 AS build
 
 WORKDIR /go/src/kubecolor
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubecolor/kubecolor
 
-go 1.26.1
+go 1.26.4
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0


### PR DESCRIPTION
# Description

Updates Go

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (doesn't directly affect users, e.g refactoring or CI/CD changes)

## Changes

- Changed version of Go

## Motivation

govulncheck was warning

```console
$ govulncheck ./...
=== Symbol Results ===

Vulnerability #1: GO-2026-5037
    Inefficient candidate hostname parsing in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2026-5037
  Standard library
    Found in: crypto/x509@go1.26.1
    Fixed in: crypto/x509@go1.26.4
    Example traces found:
      #1: config/config.go:74:51: config.LoadViper calls x509.HostnameError.Error

Your code is affected by 1 vulnerability from the Go standard library.
This scan also found 16 vulnerabilities in packages you import and 5
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
Use '-show verbose' for more details.
```

which as it says there, is solved by updating to at least 1.26.4

## Related issue (if exists)

Closes #336
