### PR TITLE
logscan: add support for Ruby-style :key=>value log format

### DIFF
--- a/scanner/logscan/logscan.go
+++ b/scanner/logscan/logscan.go
@@ -169,6 +169,26 @@ func (s *Scanner) scan(rest []byte) int {
 		}
 	}
 
+	// Ruby-style key=>value pairing, e.g. as emitted by Elastic Logstash:
+	//   :source=>"message"
+	//   :raw=>"some string with spaces"
+	//   :exception=>#<LogStash::Json::ParserError: ...>
+	//   :port=>6080
+	//
+	// See https://github.com/kubecolor/kubecolor/issues/198
+	//
+	// We keep the leading colon in the key text (e.g. ":source") so the rendered
+	// output matches what the user sees in the raw log.
+	if len(word) > 1 && word[0] == ':' {
+		if arrowIdx := bytes.Index(word, []byte("=>")); arrowIdx > 0 {
+			key := word[:arrowIdx]            // e.g. ":source"
+			valueAndRest := rest[len(key)+2:] // skip the "=>"
+			s.pushToken(KindKey, string(key))
+			s.pushToken(KindUnknown, "=>")
+			return s.scanRubyValue(valueAndRest, len(key)+2)
+		}
+	}
+
 	if key, _, ok := bytes.Cut(word, []byte("=")); ok {
 		return s.scanKeyValue(key, rest[len(key)+1:]) // +1 to skip the "=" sign
 	}
@@ -332,6 +352,103 @@ func (s *Scanner) scanKeyValue(key, valueAndRest []byte) int {
 
 	s.pushToken(KindValue, string(word))
 	return len(key) + 1 + len(word)
+}
+
+// scanRubyValue parses the value part of a Ruby-style :key=>value pair.
+//
+// totalConsumed is the number of bytes already consumed from the line for the
+// key + "=>" sequence, which is added to the return value so the caller can
+// know the full length of the token sequence it should skip.
+//
+// It handles:
+//   - quoted strings: :source=>"some string with spaces"
+//   - Ruby's #<...> inspect output (single-line): :exception=>#<Foo::Bar: baz>
+//   - parenthesised values: :opts=(foo bar)
+//   - bracketed values: :tags=[a, b]
+//   - JSON objects/arrays: :payload={"a":1}
+//   - dates: :ts=>2024-08-03T12:38:44.049832713Z
+//   - plain scalars: :port=>6080
+//
+// Multiline #<...> values (where the closing > is on a later line) are not
+// supported because the scanner operates line-by-line. The unclosed portion
+// is treated as a single word instead.
+//
+// See https://github.com/kubecolor/kubecolor/issues/198
+func (s *Scanner) scanRubyValue(valueAndRest []byte, totalConsumed int) int {
+	if len(valueAndRest) == 0 {
+		return totalConsumed
+	}
+
+	firstRune, _ := utf8.DecodeRune(valueAndRest)
+
+	switch firstRune {
+	case '"', '\'', '`':
+		if quoted := readQuoted(valueAndRest); len(quoted) != 0 {
+			s.pushToken(KindValue, string(quoted))
+			return totalConsumed + len(quoted)
+		}
+
+	case '(':
+		if group := readParenthases(valueAndRest, '(', ')'); len(group) != 0 {
+			s.pushToken(KindValue, string(group))
+			return totalConsumed + len(group)
+		}
+
+	case '[':
+		if group := readParenthases(valueAndRest, '[', ']'); len(group) != 0 {
+			s.pushToken(KindValue, string(group))
+			return totalConsumed + len(group)
+		}
+
+	case '{':
+		if written := s.scanJSON(valueAndRest); written > 0 {
+			return totalConsumed + written
+		}
+
+	case '#':
+		// Ruby's #<Type ...> inspect output. Try to balance < and > so we can
+		// capture values that contain spaces, colons, etc. on a single line.
+		//
+		// Example from the issue:
+		//   :exception=>#<LogStash::Json::ParserError: Unrecognized token 'I1125': ...>
+		//
+		// Multiline values where the closing > is on a following line cannot be
+		// captured by this line-based scanner; the unclosed prefix is treated
+		// as a single word below.
+		if len(valueAndRest) >= 2 && valueAndRest[1] == '<' {
+			depth := 0
+			index := 0
+			for index < len(valueAndRest) {
+				r, size := utf8.DecodeRune(valueAndRest[index:])
+				if r == utf8.RuneError {
+					break
+				}
+				index += size
+				switch r {
+				case '<':
+					depth++
+				case '>':
+					depth--
+					if depth == 0 {
+						s.pushToken(KindValue, string(valueAndRest[:index]))
+						return totalConsumed + index
+					}
+				}
+			}
+			// Unclosed on this line — fall through to readWord below.
+		}
+	}
+
+	word := readWord(valueAndRest)
+
+	// Treat the value as a date if the whole word looks like one.
+	if dateMatch := dateRegex.Find(word); dateMatch != nil && len(dateMatch) == len(word) {
+		s.pushToken(KindDate, string(word))
+		return totalConsumed + len(word)
+	}
+
+	s.pushToken(KindValue, string(word))
+	return totalConsumed + len(word)
 }
 
 func (s *Scanner) scanJSON(rest []byte) int {

--- a/scanner/logscan/logscan_test.go
+++ b/scanner/logscan/logscan_test.go
@@ -538,3 +538,98 @@ func TestReadLetters(t *testing.T) {
 		})
 	}
 }
+
+func TestScanner_rubyStyleKeyValue(t *testing.T) {
+	// https://github.com/kubecolor/kubecolor/issues/198
+	tests := []struct {
+		name  string
+		input string
+		want  []Token
+	}{
+		{
+			name:  "ruby :key=>\"quoted string\"",
+			input: ":source=>\"message\"\n",
+			want: []Token{
+				{Kind: KindKey, Text: ":source"},
+				{Kind: KindUnknown, Text: "=>"},
+				{Kind: KindValue, Text: "\"message\""},
+				{Kind: KindNewline, Text: "\n"},
+			},
+		},
+		{
+			name:  "ruby :key=>\"quoted string with spaces\"",
+			input: ":raw=>\"hello world foo\"\n",
+			want: []Token{
+				{Kind: KindKey, Text: ":raw"},
+				{Kind: KindUnknown, Text: "=>"},
+				{Kind: KindValue, Text: "\"hello world foo\""},
+				{Kind: KindNewline, Text: "\n"},
+			},
+		},
+		{
+			name:  "ruby :key=>plain scalar",
+			input: ":port=>6080\n",
+			want: []Token{
+				{Kind: KindKey, Text: ":port"},
+				{Kind: KindUnknown, Text: "=>"},
+				{Kind: KindValue, Text: "6080"},
+				{Kind: KindNewline, Text: "\n"},
+			},
+		},
+		{
+			name:  "ruby :key=>#<Type ...> inspect",
+			input: ":exception=>#<Foo::Bar: baz>\n",
+			want: []Token{
+				{Kind: KindKey, Text: ":exception"},
+				{Kind: KindUnknown, Text: "=>"},
+				{Kind: KindValue, Text: "#<Foo::Bar: baz>"},
+				{Kind: KindNewline, Text: "\n"},
+			},
+		},
+		{
+			name:  "ruby :key=>#<A<B>> nested angles",
+			input: ":x=>#<A<B>>\n",
+			want: []Token{
+				{Kind: KindKey, Text: ":x"},
+				{Kind: KindUnknown, Text: "=>"},
+				{Kind: KindValue, Text: "#<A<B>>"},
+				{Kind: KindNewline, Text: "\n"},
+			},
+		},
+		{
+			name:  "ruby and logfmt mixed on one line",
+			input: ":source=>\"message\" key=value\n",
+			want: []Token{
+				{Kind: KindKey, Text: ":source"},
+				{Kind: KindUnknown, Text: "=>"},
+				{Kind: KindValue, Text: "\"message\""},
+				{Kind: KindUnknown, Text: " "},
+				{Kind: KindKey, Text: "key"},
+				{Kind: KindUnknown, Text: "="},
+				{Kind: KindValue, Text: "value"},
+				{Kind: KindNewline, Text: "\n"},
+			},
+		},
+		{
+			name:  "ruby :key=>date",
+			input: ":ts=>2024-08-03T12:38:44.049832713Z\n",
+			want: []Token{
+				{Kind: KindKey, Text: ":ts"},
+				{Kind: KindUnknown, Text: "=>"},
+				{Kind: KindDate, Text: "2024-08-03T12:38:44.049832713Z"},
+				{Kind: KindNewline, Text: "\n"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scanner := NewScanner(strings.NewReader(tc.input))
+			var gotTokens []Token
+			for scanner.Scan() {
+				gotTokens = append(gotTokens, scanner.Token())
+			}
+			testutil.MustEqual(t, tc.want, gotTokens)
+		})
+	}
+}


### PR DESCRIPTION
# Description

This PR adds support for parsing and colorizing Ruby-style :key=>value log formats. These are commonly emitted by Elastic Logstash and other Ruby-based loggers.

Previously, kubecolor only understood logfmt (key=value). Because Ruby pairs contain an =, the scanner was splitting on the first = it saw (e.g., turning :source=>"message" into key :source and value >"message"). This fix detects the => sequence first and routes it to a new value parser specifically designed for Ruby log syntax.

## Type of change

- [x] Bug fix (fixes an issue)
- [x] New feature (added functionality)

## Changes

1. Added a new detection branch in scanner/logscan/logscan.go (scan() method) to identify :key=>value patterns before the standard logfmt key=value branch intercepts it.
2. Added a new scanRubyValue helper function to parse the value side of Ruby pairs. It handles:
   1. Quoted strings: :source=>"some string with spaces"
   2. Ruby's #<...> inspect output (single-line): :exception=>#<Foo::Bar: baz>
   3. Parentheses/brackets/JSON objects
   4. Dates and plain scalars
3. Added comprehensive unit tests in scanner/logscan/logscan_test.go covering quoted strings, inspect output, plain values, dates, nested angles, and mixed logfmt/ruby lines.
## Motivation

Users running Elastic Logstash or Ruby-based services get uncolored or misaligned output because kubecolor couldn't parse the :key=>value syntax. This fixes the parsing so the keys and values are correctly colorized, matching the expected behavior outlined in the issue.

## Test cases passed

```text
go test ./scanner/logscan/...
>> go test ./...
>> gofmt -w scanner/logscan/logscan.go scanner/logscan/logscan_test.go
>> go vet ./...
ok      github.com/kubecolor/kubecolor/scanner/logscan  (cached)
?       github.com/kubecolor/kubecolor  [no test files]
ok      github.com/kubecolor/kubecolor/command  (cached)
ok      github.com/kubecolor/kubecolor/config   (cached)
ok      github.com/kubecolor/kubecolor/config/color     (cached)
?       github.com/kubecolor/kubecolor/config/testconfig        [no test files]
ok      github.com/kubecolor/kubecolor/internal/bytesutil       (cached)
?       github.com/kubecolor/kubecolor/internal/cmd/configdoc   [no test files]
?       github.com/kubecolor/kubecolor/internal/cmd/configschema        [no test files]
?       github.com/kubecolor/kubecolor/internal/cmd/imagegen    [no test files]
?       github.com/kubecolor/kubecolor/internal/cmd/testcorpus  [no test files]
?       github.com/kubecolor/kubecolor/internal/ctxscanner      [no test files]
?       github.com/kubecolor/kubecolor/internal/slogutil        [no test files]
ok      github.com/kubecolor/kubecolor/internal/stringutil      (cached)
ok      github.com/kubecolor/kubecolor/internal/testcorpus      (cached)
ok      github.com/kubecolor/kubecolor/kubectl  (cached)
ok      github.com/kubecolor/kubecolor/printer  (cached)
ok      github.com/kubecolor/kubecolor/scanner/describe (cached)
ok      github.com/kubecolor/kubecolor/scanner/logscan  (cached)
ok      github.com/kubecolor/kubecolor/scanner/tablescan        (cached)
ok      github.com/kubecolor/kubecolor/test/corpus      0.895s
?       github.com/kubecolor/kubecolor/testutil [no test files]
```
## Related issue (if exists)


Closes #198 