### PR TITLE
fix(help): bracketed URLs lose their last character

### DIFF
--- a/printer/help.go
+++ b/printer/help.go
@@ -153,7 +153,7 @@ func (p *HelpPrinter) printCommandLine(w io.Writer, line string) bool {
 func (p *HelpPrinter) colorizeUrls(s string) string {
 	return urlRegex.ReplaceAllStringFunc(s, func(url string) string {
 		if url[0] == '[' {
-			return fmt.Sprintf("[%s]", p.Theme.Help.Url.Render(url[1:len(url)-2]))
+			return fmt.Sprintf("[%s]", p.Theme.Help.Url.Render(url[1:len(url)-1]))
 		}
 		return p.Theme.Help.Url.Render(url)
 	})

--- a/printer/help_test.go
+++ b/printer/help_test.go
@@ -9,6 +9,37 @@ import (
 	"github.com/kubecolor/kubecolor/testutil"
 )
 
+func TestHelpPrinter_colorizeUrls(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "bracketed url keeps last character",
+			input: "See [https://kubernetes.io/docs/reference] for more.",
+			want:  "See [https://kubernetes.io/docs/reference] for more.",
+		},
+		{
+			name:  "bare url",
+			input: "See https://kubernetes.io/docs/reference for more.",
+			want:  "See https://kubernetes.io/docs/reference for more.",
+		},
+		{
+			name:  "multiple bracketed urls",
+			input: "a [http://golang.org/pkg/text/template/#pkg-overview] b [https://kubernetes.io/docs/reference/kubectl/jsonpath/] c",
+			want:  "a [http://golang.org/pkg/text/template/#pkg-overview] b [https://kubernetes.io/docs/reference/kubectl/jsonpath/] c",
+		},
+	}
+
+	printer := HelpPrinter{Theme: testconfig.NullTheme}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			testutil.Equal(t, tc.want, printer.colorizeUrls(tc.input), "colorized urls")
+		})
+	}
+}
+
 func TestHelpPrinter_fail(t *testing.T) {
 	var logBuf bytes.Buffer
 	testutil.SetTestLogger(t, &logBuf)

--- a/test/corpus/help.txt
+++ b/test/corpus/help.txt
@@ -352,7 +352,7 @@ Use "kubectl options" for a list of global command-line options (applies to all 
 	[37mWhen using the default or custom-column output format, don't print headers (default print headers).[0m
 
     [36m-o, --output[0m=[93m''[0m:
-	[37mOutput format. One of: (json, yaml, name, go-template, go-template-file, template, templatefile, jsonpath, jsonpath-as-json, jsonpath-file, custom-columns, custom-columns-file, wide). See custom columns [[36mhttps://kubernetes.io/docs/reference/kubectl/#custom-column[0m[37m], golang template [[36mhttp://golang.org/pkg/text/template/#pkg-overvie[0m[37m] and jsonpath template [[36mhttps://kubernetes.io/docs/reference/kubectl/jsonpath[0m[37m].[0m
+	[37mOutput format. One of: (json, yaml, name, go-template, go-template-file, template, templatefile, jsonpath, jsonpath-as-json, jsonpath-file, custom-columns, custom-columns-file, wide). See custom columns [[36mhttps://kubernetes.io/docs/reference/kubectl/#custom-columns[0m[37m], golang template [[36mhttp://golang.org/pkg/text/template/#pkg-overview[0m[37m] and jsonpath template [[36mhttps://kubernetes.io/docs/reference/kubectl/jsonpath/[0m[37m].[0m
 
     [36m--output-watch-events[0m=[31mfalse[0m:
 	[37mOutput watch event objects when --watch or --watch-only is used. Existing objects are output as initial ADDED events.[0m
@@ -385,7 +385,7 @@ Use "kubectl options" for a list of global command-line options (applies to all 
 	[37mIf specified, gets the subresource of the requested object. Must be one of [status scale]. This flag is beta and may change in the future.[0m
 
     [36m--template[0m=[93m''[0m:
-	[37mTemplate string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [[36mhttp://golang.org/pkg/text/template/#pkg-overvie[0m[37m].[0m
+	[37mTemplate string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [[36mhttp://golang.org/pkg/text/template/#pkg-overview[0m[37m].[0m
 
     [36m-w, --watch[0m=[31mfalse[0m:
 	[37mAfter listing/getting the requested object, watch for changes.[0m


### PR DESCRIPTION
# Description

A bracketed URL in help output loses its last character, so any link copied out of `kubectl ... --help` through kubecolor is broken.

```
$ kubecolor --force-colors get --help | cat -v
 ^[[37mSee [^[[36mhttps://kubernetes.io/docs/referenc^[[0m^[[37m] for more.^[[0m
```

The trailing `e` of `reference` is gone.

The committed corpus already records the corruption. `test/corpus/help.txt` stores both the raw kubectl input and the expected output, and the two disagree:

| input says | output says |
|---|---|
| `#custom-columns` | `#custom-column` |
| `#pkg-overview` | `#pkg-overvie` |
| `.../jsonpath/` | `.../jsonpath` |

## Type of change

- [x] Bug fix (fixes an issue)

## Changes

- Fixed `colorizeUrls` in `printer/help.go` slicing one character too many off the end of a matched URL.
- Added `TestHelpPrinter_colorizeUrls` in `printer/help_test.go`, covering a single bracketed URL and several on one line.
- Regenerated `test/corpus/help.txt` with `make corpus-update`.

The regex capture group is `\[(https?://...[^\]]+)\]`, so the match already excludes the closing `]`. The old code stripped two trailing characters, removing a bracket that was not there plus one real character of the URL:

```go
p.Theme.Help.Url.Render(url[1:len(url)-2])   // before
p.Theme.Help.Url.Render(url[1:len(url)-1])   // after
```

After:

```
 ^[[37mSee [^[[36mhttps://kubernetes.io/docs/reference^[[0m^[[37m] for more.^[[0m
```

On the corpus: `make corpus-update` regenerated it, and only `help.txt` changed, exactly the lines above. The other twenty corpus files reported unchanged. Nothing was hand-edited, and no live `kubectl` is needed since the corpus stores its own input.

## Motivation

The output is wrong in a way that is silent and easy to miss, since a truncated URL still looks like a URL. It only shows up when someone clicks or copies it. The corpus disagreeing with its own input is what makes this unambiguous rather than a judgement call.

## Related issue (if exists)

None found.

## Verification

With the fix reverted, both the new unit test and the corpus test fail, so the regression is caught at both layers. `go test ./...` passes.

---

*Apologies for the original description not following the template, I have rewritten it above to match. Disclosure: written with AI assistance (Claude Code); I ran the reproduction, the corpus regeneration and the revert check myself.*