### PR TITLE
Update to Go 1.26.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.26.5 AS build
+FROM docker.io/library/golang:1.26.6 AS build
 
 WORKDIR /go/src/kubecolor
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubecolor/kubecolor
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0


### PR DESCRIPTION
# Description

Update Go to resolve vulnerability

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (doesn't directly affect users, e.g refactoring or CI/CD changes)

## Changes

- Changed Go version

## Motivation

Resolves vulnerability warning:

```console
$ govulncheck ./...
=== Symbol Results ===

Vulnerability #1: GO-2026-5972
    Enforce maximum recursion depth in encoding/asn1
  More info: https://pkg.go.dev/vuln/GO-2026-5972
  Standard library
    Found in: encoding/asn1@go1.26.5
    Fixed in: encoding/asn1@go1.26.6
    Example traces found:
      #1: testutil/heredoc.go:21:32: testutil.NewHereDocf calls strings.Replacer.Replace, which eventually calls asn1.Unmarshal
```

The vulnerability only affects our `testutil` package, so this does not need to be announced as a "vulnerability fix"


Closes #357