### PR TITLE
Stop running govulncheck in PRs

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,12 +1,9 @@
 name: govulncheck
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
   schedule:
     - cron: 0 8 * * 1 # 08:00 on mondays
+  workflow_dispatch: # allow for triggering manually
 
 permissions: {}
 


### PR DESCRIPTION
# Description

Changes our `govulncheck` workflow so it stops being a blocker for PRs

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (doesn't directly affect users, e.g refactoring or CI/CD changes)

## Changes

<!-- What was changed, technically? -->

- Changed `govulncheck.yml` to not run on PRs or main branch anymore
- Added so we can trigger the workflow manually, on-demand

## Motivation

It was very annoying having the `govulncheck` error on all PRs, as fixing the govulncheck issues is often out of scope for the PR.

Being able to manually trigger the workflow too is a nice to have.
