### PR TITLE
docs: fix ThemeDescribe doc comment naming ThemeApply

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -387,7 +387,7 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "description": "ThemeApply holds colors for the \"kubectl apply\" output."
+      "description": "ThemeDescribe holds colors for the \"kubectl describe\" output."
     },
     "themeDiff": {
       "properties": {

--- a/config/theme.go
+++ b/config/theme.go
@@ -405,7 +405,7 @@ type ThemeStderr struct {
 	Default color.Color `jsonschema_extras:"deprecated=true"` // *deprecated: this field is no longer used (since v0.4.0)*
 }
 
-// ThemeApply holds colors for the "kubectl apply" output.
+// ThemeDescribe holds colors for the "kubectl describe" output.
 type ThemeDescribe struct {
 	Key color.Slice `defaultFrom:"theme.base.key"` // used on keys. The multiple colors are cycled based on indentation.
 }


### PR DESCRIPTION
_Disclosure: this patch was prepared with AI assistance (Claude Opus 5). I checked the surrounding types and regenerated the schema myself before opening this._

### Problem

`ThemeDescribe` and `ThemeApply` sit next to each other in `config/theme.go` and carry the same doc comment:

```go
// ThemeApply holds colors for the "kubectl apply" output.
type ThemeDescribe struct {
	Key color.Slice `defaultFrom:"theme.base.key"`
}

// ThemeApply holds colors for the "kubectl apply" output.
type ThemeApply struct {
```

Every other `Theme*` type in the file follows the `ThemeX holds colors for the "kubectl x" output` pattern — `ThemeDelete`, `ThemeCreate`, `ThemeExpose`, `ThemeScale`, `ThemeRollout` — so `ThemeDescribe` is the odd one out rather than a deliberate wording choice.

### Fix

One line in `config/theme.go`, plus `config-schema.json` regenerated with `make config-schema.json` as CONTRIBUTING describes — the wrong text had propagated to `$defs.themeDescribe.description`. The regeneration touched exactly that one line, nothing else.

### Testing

`go build ./...` and `go vet ./...` are clean.

`TestCorpus` fails locally, but it fails on a clean `main` too — with more cases than with this patch applied — so it is unrelated to this change (it looks environment-dependent, likely TTY detection).
